### PR TITLE
docs: agregar limitaciones conocidas de la librería

### DIFF
--- a/docs/limitaciones.md
+++ b/docs/limitaciones.md
@@ -1,0 +1,53 @@
+ # Limitaciones de la librería Trazo
+
+A continuación se describen las limitaciones conocidas de la librería Trazo en su versión actual:
+
+---
+
+## 1. Precisión limitada por uso de JavaScript
+
+**Descripción:**  
+La librería utiliza el tipo de dato `Number` de JavaScript, lo que puede generar errores de precisión en cálculos numéricos.
+
+**Workaround:**  
+Ajustar tolerancias en los métodos numéricos o utilizar librerías externas de alta precisión si es necesario.
+
+---
+
+## 2. Dependencia de valores iniciales adecuados
+
+**Descripción:**  
+Algunos métodos como Newton-Raphson, secante o punto fijo requieren valores iniciales adecuados para converger correctamente.
+
+**Workaround:**  
+Elegir valores iniciales cercanos a la solución esperada o validar previamente el comportamiento de la función.
+
+---
+
+## 3. Métodos no completamente optimizados
+
+**Descripción:**  
+Al ser una librería en desarrollo, algunos métodos pueden no estar optimizados en rendimiento o estabilidad.
+
+**Workaround:**  
+Probar distintos métodos disponibles y comparar resultados.
+
+---
+
+## 4. Manejo limitado de errores
+
+**Descripción:**  
+La librería puede no manejar todos los casos de error, como divisiones por cero o entradas inválidas.
+
+**Workaround:**  
+Validar manualmente los datos de entrada antes de ejecutar los métodos.
+
+---
+
+## 5. Soporte limitado para funciones complejas
+
+**Descripción:**  
+Algunos métodos pueden fallar con funciones no continuas o muy complejas.
+
+**Workaround:**  
+Simplificar la función o dividir el problema en intervalos más pequeños.


### PR DESCRIPTION
## ¿Qué hace este PR?
Este PR agrega el archivo docs/limitaciones.md con las limitaciones conocidas de la librería Trazo en su versión inicial.
Se documentan restricciones actuales de los métodos numéricos y posibles alternativas o soluciones temporales.
## Issue relacionado
Closes #54

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [x ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x ] Mi código sigue los estándares del proyecto
- [x ] Actualicé la documentación correspondiente
- [x ] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
No aplica (cambio de documentación)
