### PR TITLE
feat: implementar funciones det2x2 y det3x3

### DIFF
--- a/src/linearAlgebra/determinant.js
+++ b/src/linearAlgebra/determinant.js
@@ -1,0 +1,37 @@
+/**
+ * Calcula el determinante de una matriz 2x2
+ * @param {number[][]} m - matriz 2x2
+ * @returns {number}
+ */
+export function det2x2(m) {
+  if (!Array.isArray(m) || m.length !== 2 || m.some(row => row.length !== 2)) {
+    throw new Error("La matriz debe ser 2x2");
+  }
+
+  const [[a, b], [c, d]] = m;
+
+  return a * d - b * c;
+}
+
+/**
+ * Calcula el determinante de una matriz 3x3
+ * @param {number[][]} m - matriz 3x3
+ * @returns {number}
+ */
+export function det3x3(m) {
+  if (!Array.isArray(m) || m.length !== 3 || m.some(row => row.length !== 3)) {
+    throw new Error("La matriz debe ser 3x3");
+  }
+
+  const [
+    [a, b, c],
+    [d, e, f],
+    [g, h, i]
+  ] = m;
+
+  return (
+    a * (e * i - f * h) -
+    b * (d * i - f * g) +
+    c * (d * h - e * g)
+  );
+}


### PR DESCRIPTION
## ¿Qué hace este PR?

Implementa funciones para calcular determinantes de matrices 2x2 y 3x3

## Issue relacionado
Closes #37 

## Tipo de cambio
- [x] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas

Ejemplo:

det2x2([[1,2],[3,4]]) → -2  
det3x3([[1,2,3],[4,5,6],[7,8,9]]) → 0

<img width="2460" height="1340" alt="image" src="https://github.com/user-attachments/assets/a3262a6d-bc90-4ec4-9615-56a75c925d54" />

