### PR TITLE
feat: crear NumericalError personalizada #33

### DIFF
--- a/src/errors/NumericalError.js
+++ b/src/errors/NumericalError.js
@@ -1,0 +1,16 @@
+
+class NumericalError extends Error {
+    /**
+     * @param {string} message - Mensaje descriptivo del error.
+     * @param {string} code - Código identificador del error.
+     * @param {string} methodName - Nombre del método numérico que falló.
+     */
+    constructor(message, code, methodName) {
+        super(message);
+        this.name = "NumericalError";
+        this.code = code;
+        this.methodName = methodName;
+    }
+}
+
+module.exports = NumericalError;


### PR DESCRIPTION
## ¿Qué hace este PR?
Crea src/errors/NumericalError.js con una excepción personalizada
que extiende Error. Incluye campos code y methodName para identificar
el método numérico que falló. Lista para usar en métodos de raíz.

## Issue relacionado
Closes #33

## Tipo de cambio
- [x] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [x] Agregué tests si corresponde

## Evidencia / capturas
<img width="607" height="338" alt="image" src="https://github.com/user-attachments/assets/e82153f1-c922-4978-908b-71c732b79227" />
