### PR TITLE
feat: crear index.js con exports nombrados

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -1,6 +1,54 @@
-export * from './core/index.js';
-export * from './no-lineales/index.js';
-export * from './lineales/index.js';
-export * from './integracion/index.js';
-export * from './interpolacion/index.js';
-export *from './utils/index.js';
+/**
+ * Re-exporta la función pública para cálculo de derivadas.
+ */
+export { derivative } from './calculus/derivative.js';
+
+/**
+ * Re-exporta el método público de integración Simpson 1/3.
+ */
+export { simpson13 } from './integracion/simpson-13.js';
+
+/**
+ * Re-exporta el método público de integración Simpson.
+ */
+export { simpson } from './integration/simpson.js';
+
+/**
+ * Re-exporta la función pública para interpolación de Lagrange.
+ */
+export { lagrange } from './interpolacion/lagrange.js';
+
+/**
+ * Re-exporta la función pública para interpolación lineal.
+ */
+export { linearInterpolation } from './interpolacion/linear.js';
+
+/**
+ * Re-exporta el método público de eliminación de Gauss.
+ */
+export { gauss } from './lineales/gauss.js';
+
+/**
+ * Re-exporta el método público de Jacobi.
+ */
+export { jacobi } from './lineales/jacobi.js';
+
+/**
+ * Re-exporta la función pública para determinantes de matrices 2x2.
+ */
+export { det2x2 } from './linearAlgebra/determinant.js';
+
+/**
+ * Re-exporta la función pública para determinantes de matrices 3x3.
+ */
+export { det3x3 } from './linearAlgebra/determinant.js';
+
+/**
+ * Re-exporta la función pública para evaluación de polinomios.
+ */
+export { polyEval } from './math/polyEval.js';
+
+/**
+ * Re-exporta el método público de Newton-Raphson.
+ */
+export { newtonRaphson } from './no-lineales/newton-raphson.js';


### PR DESCRIPTION
## ¿Qué hace este PR?
Crea el punto de entrada público del paquete en `src/index.js`, reemplazando los `export *` por exports nombrados.

Se re-exportan las funciones públicas existentes desde sus respectivos submódulos y se agrega JSDoc antes de cada export, sin agregar lógica nueva.

## Issue relacionado
Closes #22 

## Tipo de cambio
- [x] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
Se verificó la importación de `src/index.js` con el siguiente comando:

```bash
node -e "import('./src/index.js').then(m => console.log(Object.keys(m)))"
```
<img width="708" height="248" alt="Captura de pantalla 2026-05-15 122801" src="https://github.com/user-attachments/assets/d70b24c2-ba00-41e1-b9bb-5246749bd10c" />
