### PR TITLE
chore: configurar .npmignore para excluir archivos de desarrollo

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,0 +1,26 @@
+# Git
+.git/
+.github/
+
+# Docs
+docs/
+README.md
+CONTRIBUTING.md
+CHANGELOG.md
+
+# Tests
+test/
+tests/
+
+# Config
+.eslintrc
+.eslintrc.js
+.eslintrc.json
+eslint.config.js
+rollup.config.mjs
+
+# Data
+data/
+
+# Security
+security/


### PR DESCRIPTION
## ¿Qué hace este PR?

Configura `.npmignore` para excluir archivos innecesarios del paquete publicado.

## Issue relacionado
Closes #30 

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [x] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas

Se verificó el empaquetado con:

npm pack --dry-run
<img width="1166" height="1316" alt="image" src="https://github.com/user-attachments/assets/52dea796-4c37-4814-852e-dcb866a01634" />
