### PR TITLE
fix: corregir la exportación de biseccion en index.js para usar named…

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -51,4 +51,13 @@ export { polyEval } from './math/polyEval.js';
 /**
  * Re-exporta el método público de Newton-Raphson.
  */
-export { newtonRaphson } from './no-lineales/newton-raphson.js';
+export { newtonRaphson } from './no-lineales/newton-raphson.js'
+/**
+
+* Agrupador para métodos no lineales.
+ */
+import { biseccion } from './no-lineales/biseccion.js';
+export { biseccion };
+export const noLineales = {
+  biseccion
+};


### PR DESCRIPTION
## ¿Qué hace este PR?
Corrige y estandariza la exportación del módulo `biseccion` en el archivo `src/index.js`. Se implementó una exportación nombrada directa para permitir el acceso inmediato al algoritmo, y de manera simultánea, se integró dentro de un objeto contenedor inmutable denominado `noLineales`. Esto garantiza que ambas vías de importación apunten exactamente a la misma referencia en memoria, resolviendo la inconsistencia arquitectónica sin alterar la lógica interna de la función.

## Issue relacionado
Closes #203

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [x] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
Se verifico en el entorno de ejecución interactivo de Node.js (REPL) que confirmaron el cumplimiento de los criterios de aceptación automatizados:
<img width="591" height="253" alt="image" src="https://github.com/user-attachments/assets/375b6552-3457-4c14-9e8d-7b8fbb7a9f18" />
