### PR TITLE
fix: actualizar .gitignore para excluir archivos generados

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,6 +52,7 @@ target/
 coverage/
 .coverage
 htmlcov/
+.nyc_output/
 
 # Datos sensibles
 *.pem


### PR DESCRIPTION
## ¿Qué hace este PR?

Actualiza `.gitignore` agregando reglas faltantes para excluir archivos generados automáticamente y dependencias.

## Issue relacionado
Closes #199 

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [x] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas

Se verificó que:

- `node_modules/` está ignorado
- `coverage/` está ignorado
- `.nyc_output/` está ignorado
- `dist/` está ignorado

<img width="1986" height="1180" alt="image" src="https://github.com/user-attachments/assets/d48bacb0-28b8-4465-b01e-d7c16e13c65e" />

Además, `package-lock.json` mantiene el tratamiento actual del proyecto.
