### PR TITLE
fix: agregar archivos base de validaciones y contrato

### DIFF
--- a/src/core/contrato.js
+++ b/src/core/contrato.js
@@ -1,0 +1,11 @@
+/**
+ * Construye un resultado estándar.
+ * @param {*} resultado
+ * @returns {Object}
+ */
+export function construirResultado(resultado) {
+  return {
+    ok: true,
+    resultado
+  };
+}

--- a/src/core/validaciones.js
+++ b/src/core/validaciones.js
@@ -1,0 +1,49 @@
+/**
+ * Verifica si el argumento es una función.
+ * @param {*} fn
+ */
+export function validarFuncion(fn) {
+  if (typeof fn !== 'function') {
+    throw new Error('El argumento debe ser una función');
+  }
+}
+
+/**
+ * Verifica si el argumento es un número finito.
+ * @param {*} n
+ */
+export function validarNumero(n) {
+  if (typeof n !== 'number' || !Number.isFinite(n)) {
+    throw new Error('El argumento debe ser un número válido');
+  }
+}
+
+/**
+ * Verifica si el intervalo es válido.
+ * @param {number} a
+ * @param {number} b
+ */
+export function validarIntervalo(a, b) {
+  validarNumero(a);
+  validarNumero(b);
+
+  if (a >= b) {
+    throw new Error('El valor a debe ser menor que b');
+  }
+}
+
+/**
+ * Verifica si una matriz es cuadrada.
+ * @param {Array<Array<number>>} matriz
+ */
+export function validarMatrizCuadrada(matriz) {
+  if (
+    !Array.isArray(matriz) ||
+    matriz.length === 0 ||
+    !matriz.every(
+      fila => Array.isArray(fila) && fila.length === matriz.length
+    )
+  ) {
+    throw new Error('La matriz debe ser cuadrada');
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -51,7 +51,7 @@ export { polyEval } from './math/polyEval.js';
 /**
  * Re-exporta el método público de Newton-Raphson.
  */
-export { newtonRaphson } from './no-lineales/newton-raphson.js'
+export { newtonRaphson } from './no-lineales/newton-raphson.js';
 /**
 
 * Agrupador para métodos no lineales.

--- a/test.js
+++ b/test.js
@@ -1,0 +1,11 @@
+import {
+  validarNumero,
+  validarIntervalo
+} from './src/core/validaciones.js';
+
+import { construirResultado } from './src/core/contrato.js';
+
+validarNumero(5);
+validarIntervalo(1, 10);
+
+console.log(construirResultado(25));


### PR DESCRIPTION
## ¿Qué hace este PR?

Agrega los archivos base `validaciones.js` y `contrato.js` dentro de `src/core` para soportar validaciones reutilizables y construcción estándar de resultados.

## Issue relacionado

Closes #196

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [x] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [x] Agregué tests si corresponde

## Evidencia / capturas

<img width="1291" height="993" alt="image" src="https://github.com/user-attachments/assets/dc2eeb2b-4ed4-4ac8-b794-c0bbc66c8c31" />

<img width="1217" height="1052" alt="image" src="https://github.com/user-attachments/assets/471819c5-1523-4921-9e59-cf1e7574aa4c" />

