### PR TITLE
feat(integracion): implementar regla de Simpson 3/8 #107

### DIFF
--- a/src/integracion/simpson-38.js
+++ b/src/integracion/simpson-38.js
@@ -1,37 +1,76 @@
+import { crearResultado } from '../core/contrato.js';
+import { ErrorParametros } from '../core/errores.js';
+import { validarFuncion, validarIntervalo } from '../utils/validaciones.js';
+
+/**
+ * Aproxima una integral definida usando la regla de Simpson 3/8.
+ * Requiere que el número de subintervalos sea múltiplo de 3.
+ *
+ * @param {Object}   opciones
+ * @param {Function} opciones.f  
+ * @param {number}   opciones.a  
+ * @param {number}   opciones.b  
+ * @param {number}   [opciones.n=99] 
+ * @returns {Object} 
+ * @throws {ErrorParametros} 
+ *
+ * @example
+ * const res = simpson38({ f: (x) => x ** 2, a: 0, b: 1, n: 9 });
+ * // res.resultado ≈ 0.3333
+ */
 export function simpson38({ f, a, b, n = 99 }) {
-  if (n % 3 !== 0) {
-    throw new Error("n debe ser múltiplo de 3");
-  }
 
-  const h = (b - a) / n;
+    // Validaciones
+    validarFuncion(f, 'f');
+    validarIntervalo(a, b);
 
-  let sumaNoMultiplos3 = 0;
-  let sumaMultiplos3 = 0;
-  let iteraciones = 0;
-
-  for (let i = 1; i < n; i++) {
-    const x = a + i * h;
-
-    if (i % 3 === 0) {
-      sumaMultiplos3 += f(x);
-    } else {
-      sumaNoMultiplos3 += f(x);
+    if (!Number.isInteger(n) || n <= 0) {
+        throw new ErrorParametros(
+            `Trazo: 'n' debe ser un entero positivo. Se recibió: ${n}.`
+        );
     }
 
-    iteraciones++;
-  }
+    if (n % 3 !== 0) {
+        throw new ErrorParametros(
+            `Trazo: 'n' debe ser múltiplo de 3. Se recibió: ${n}.`
+        );
+    }
 
-  const resultado =
-    (3 * h / 8) *
-    (
-      f(a) +
-      3 * sumaNoMultiplos3 +
-      2 * sumaMultiplos3 +
-      f(b)
-    );
+    const h = (b - a) / n;
+    const iteraciones = [];
 
-  return {
-    resultado,
-    iteraciones
-  };
+    // Calcular puntos y coeficientes
+    let suma = 0;
+
+    for (let i = 0; i <= n; i++) {
+        const xi  = a + i * h;
+        const fxi = f(xi);
+        let coeficiente;
+
+        if (i === 0 || i === n) {
+            coeficiente = 1;
+        } else if (i % 3 === 0) {
+            coeficiente = 2;
+        } else {
+            coeficiente = 3;
+        }
+
+        suma += coeficiente * fxi;
+
+        iteraciones.push({ i, xi, fxi, coeficiente });
+    }
+
+    const resultado = (3 * h / 8) * suma;
+
+    return crearResultado({
+        resultado,
+        iteraciones,
+        convergio: true,
+        mensaje: `Simpson 3/8 completado con ${n} subintervalos.`,
+        meta: {
+            metodo: 'Simpson 3/8',
+            parametros: { a, b, n },
+            tiempo_ms: 0,
+        },
+    });
 }


### PR DESCRIPTION
## ¿Qué hace este PR?
Crea src/integracion/simpson-38.js con la función simpson38()
que aproxima integrales usando la regla de Simpson 3/8.
Valida que n sea múltiplo de 3, aplica coeficientes 1, 3 y 2
según posición y devuelve el objeto del contrato.
Para f(x)=x², a=0, b=1, n=9 el resultado es aproximadamente 0.3333.


## Issue relacionado
Closes #107

## Tipo de cambio
- [x] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
No aplica