### PR TITLE
feat(integracion): implementar regla de Simpson 1/3 

### DIFF
--- a/src/integracion/simpson-13.js
+++ b/src/integracion/simpson-13.js
@@ -1,69 +1,65 @@
-// METODO DE SIMPSON-13
-
+/**
+ * Regla de Simpson 1/3 para aproximacion de integrales.
+ *
+ * @param {Object} params Parametros del metodo.
+ * @param {Function} params.f Funcion a integrar.
+ * @param {number} params.a Extremo inferior.
+ * @param {number} params.b Extremo superior.
+ * @param {number} [params.n=100] Numero de subintervalos (par).
+ * @returns {Object} Resultado del metodo.
+ */
 function simpson13({ f, a, b, n = 100 }) {
- 
   if (typeof f !== "function") {
-    throw new TypeError(
-      `Trazo.simpson13: 'f' debe ser una función. Se recibió: ${typeof f}`
-    );
+    throw new TypeError("f debe ser una función.");
   }
- 
-  if (typeof a !== "number" || isNaN(a)) {
-    throw new TypeError(
-      `Trazo.simpson13: 'a' debe ser un número válido. Se recibió: ${a}`
-    );
+
+  if (typeof a !== "number" || typeof b !== "number" || a >= b) {
+    throw new Error("Intervalo inválido.");
   }
- 
-  if (typeof b !== "number" || isNaN(b)) {
-    throw new TypeError(
-      `Trazo.simpson13: 'b' debe ser un número válido. Se recibió: ${b}`
-    );
+
+  if (!Number.isInteger(n) || n <= 0 || n % 2 !== 0) {
+    throw new Error("n debe ser un entero positivo y par.");
   }
- 
-  if (a >= b) {
-    throw new Error(
-      `Trazo.simpson13: el límite inferior 'a' (${a}) debe ser menor que el límite superior 'b' (${b}).`
-    );
-  }
- 
-  if (typeof n !== "number" || !Number.isInteger(n) || n < 2) {
-    throw new TypeError(
-      `Trazo.simpson13: 'n' debe ser un entero mayor o igual a 2. Se recibió: ${n}`
-    );
-  }
- 
-  if (n % 2 !== 0) {
-    throw new Error(
-      `Trazo.simpson13: 'n' debe ser un número par. Se recibió n = ${n}. ` +
-      `Considera usar n = ${n + 1} o n = ${n - 1}.`
-    );
-  }
- 
+
   const h = (b - a) / n;
+
+  let suma = 0;
+
   const iteraciones = [];
- 
+
   for (let i = 0; i <= n; i++) {
     const xi = a + i * h;
-    iteraciones.push(f(xi));
-  }
- 
-  let suma = iteraciones[0] + iteraciones[n]; 
- 
-  for (let i = 1; i < n; i++) {
-    if (i % 2 !== 0) {
-      suma += 4 * iteraciones[i]; 
+    const fxi = f(xi);
+
+    let coeficiente;
+
+    if (i === 0 || i === n) {
+      coeficiente = 1;
+    } else if (i % 2 === 0) {
+      coeficiente = 2;
     } else {
-      suma += 2 * iteraciones[i]; 
+      coeficiente = 4;
     }
+
+    suma += coeficiente * fxi;
+
+    iteraciones.push({
+      i,
+      xi,
+      fxi,
+      coeficiente,
+    });
   }
- 
+
   const resultado = (h / 3) * suma;
- 
+
   return {
+    metodo: "Regla de Simpson 1/3",
     resultado,
     iteraciones,
   };
 }
- 
+
 export { simpson13 };
- 
+
+export default simpson13;


### PR DESCRIPTION
## ¿Qué hace este PR?

Implementa la regla de Simpson 1/3 para la aproximación numérica de integrales definidas. El método utiliza interpolación cuadrática con coeficientes 1, 4 y 2 para aproximar el área bajo la curva en un intervalo dividido en subintervalos pares.

Incluye validación de parámetros de entrada (función, intervalo y número de subintervalos), cálculo iterativo y registro detallado de cada iteración con (i, xi, f(xi), coeficiente) para trazabilidad del algoritmo.

## Issue relacionado
Closes #106

## Tipo de cambio
- [x] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
<img width="1505" height="798" alt="Prueba" src="https://github.com/user-attachments/assets/289b8246-a1f5-497f-9344-a55bd0295e63" />