### PR TITLE
chore: refresh .gitkeep for verification

### DIFF
--- a/src/edo/.gitkeep
+++ b/src/edo/.gitkeep
@@ -1,0 +1,1 @@
+"placeholder" 


### PR DESCRIPTION
## ¿Qué hace este PR?
Este PR asegura la existencia del directorio `src/edo` en el repositorio agregando un archivo `.gitkeep`.
Esto permite que Git versione el directorio aunque esté vacío, evitando que desaparezca al clonar el repositorio.

## Issue relacionado
Closes #207 

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [x] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [x] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas