### PR TITLE
fix(docs): actualizar docs/despliegue.md con instrucciones de publica…

### DIFF
--- a/docs/despliegue.md
+++ b/docs/despliegue.md
@@ -21,7 +21,7 @@ npm -v
 1. Clonar repositorio:
 
 ```bash
-git clone https://github.com/sis-inf/trazo.git
+git clone [https://github.com/sis-inf/trazo.git](https://github.com/sis-inf/trazo.git)
 cd trazo
 ```
 
@@ -72,11 +72,55 @@ API_URL=http://localhost:3000
 
 ## Producción
 
-Publicar en npm:
+Para publicar oficialmente una nueva versión de la librería en el registro de npm, se debe iniciar sesión en la plataforma y seguir estrictamente el flujo secuencial de empaquetado y versionado:
+
+### 1. Iniciar sesión en npm
 
 ```bash
 npm login
+```
+
+### 2. Preparar el release
+
+Antes de subir los cambios, es obligatorio actualizar el historial y el identificador del paquete:
+
+* **Actualizar el CHANGELOG:** Registrar de forma clara todos los cambios, correcciones y nuevas funcionalidades añadidas en este ciclo de desarrollo.
+* **Incrementar la versión:** Utilizar el comando de npm para actualizar el archivo `package.json` siguiendo el versionado semántico (Semantic Versioning):
+
+```bash
+npm version [patch | minor | major]
+```
+
+### 3. Generar el build
+
+Compilar el código fuente para generar los archivos de distribución finales listos para producción:
+
+```bash
+npm run build
+```
+
+### 4. Verificar el paquete (Simulación)
+
+Para garantizar que solo los archivos necesarios sean incluidos en la distribución final (evitando subir dependencias de desarrollo o archivos de configuración local), simule el empaquetado ejecutando:
+
+```bash
+npm pack --dry-run
+```
+
+### 5. Publicar en npm
+
+Una vez verificado el paquete simulado, proceda con la publicación oficial en el registro público:
+
+```bash
 npm publish
+```
+
+### 6. Crear tag de release en GitHub
+
+Para mantener sincronizado el historial de Git con las versiones distribuidas, genere una etiqueta de lanzamiento apuntando al estado actual de la rama y súbala al repositorio remoto:
+
+```bash
+git tag v0.x.x && git push --tags
 ```
 
 ---


### PR DESCRIPTION
## ¿Qué hace este PR?
Expande de forma detallada y secuencial el proceso de empaquetado y publicación de la librería en el registro público de npm dentro del documento `docs/despliegue.md`. Se estructuró formalmente el flujo de producción abarcando el inicio de sesión, la actualización del CHANGELOG y versión, la compilación del build, la verificación preventiva del paquete mediante simulación y el etiquetado de lanzamiento en Git.

## Issue relacionado
Closes #351

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [x] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
<img width="568" height="174" alt="image" src="https://github.com/user-attachments/assets/5ed5b6aa-b934-4061-8061-85dfc01ae7fc" />

