### PR TITLE
chore: actualización en npmignore para excluir archivos de desarrollo

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -4,20 +4,25 @@
 
 # Docs
 docs/
-README.md
 CONTRIBUTING.md
 CHANGELOG.md
 
 # Tests
 test/
 tests/
+coverage/
+*.test.js
+test.js
 
 # Config
+.editorconfig
 .eslintrc
 .eslintrc.js
 .eslintrc.json
+.prettierrc.json
 eslint.config.js
 rollup.config.mjs
+jest.config.js
 
 # Data
 data/


### PR DESCRIPTION
## ¿Qué hace este PR?

Actualiza `.npmignore` para excluir archivos y directorios de desarrollo que no deben formar parte del paquete publicado en NPM.

Se añadieron reglas para excluir archivos de configuración, pruebas y cobertura que no son necesarios para los usuarios finales de la librería.

Además, se verificó el contenido del paquete generado mediante npm pack --dry-run para asegurar que únicamente se distribuyan los archivos requeridos.

## Issue relacionado
Closes #283 

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [x] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
Se verificó que archivos de desarrollo y pruebas no formen parte del paquete distribuido.

<img width="1560" height="1324" alt="image" src="https://github.com/user-attachments/assets/37c62fb3-bfb6-430e-a9c6-57642859ca46" />

<img width="986" height="952" alt="image" src="https://github.com/user-attachments/assets/300ef278-fa65-400b-aa41-c56031e94747" />