### PR TITLE
docs: crear estilo-commits

### DIFF
--- a/docs/estilo-commits.md
+++ b/docs/estilo-commits.md
@@ -1,0 +1,140 @@
+# Estilo de Commits para Trazo
+
+## Introducción
+
+El proyecto Trazo utiliza la convención *Conventional Commits* para mantener un historial claro y consistente.
+
+## Formato
+
+text
+tipo(ambito): descripción breve
+
+
+### Ejemplos
+
+text
+feat(no-lineales): agregar método de secante
+fix(lineales): corregir validación de matrices
+docs(interpolacion): actualizar documentación
+
+
+---
+
+## Tipos de commit
+
+| Tipo     | Descripción                                 |
+| -------- | ------------------------------------------- |
+| feat     | Nueva funcionalidad                         |
+| fix      | Corrección de errores                       |
+| docs     | Cambios en documentación                    |
+| test     | Agregar o modificar pruebas                 |
+| refactor | Mejoras internas sin cambiar comportamiento |
+| chore    | Tareas de mantenimiento                     |
+| ci       | Configuración de integración continua       |
+
+---
+
+## Ámbitos recomendados
+
+| Ámbito        | Uso                                 |
+| ------------- | ----------------------------------- |
+| no-lineales   | Métodos no lineales                 |
+| lineales      | Métodos lineales                    |
+| integracion   | Métodos de integración numérica     |
+| interpolacion | Métodos de interpolación            |
+| edo           | Ecuaciones diferenciales ordinarias |
+| utils         | Utilidades y validaciones           |
+| io            | Entrada y salida de datos           |
+| docs          | Documentación                       |
+| ci            | Integración continua                |
+| tests         | Pruebas automatizadas               |
+
+---
+
+## Ejemplos correctos
+
+text
+feat(no-lineales): implementar método de bisección
+feat(lineales): agregar método LU
+fix(interpolacion): corregir cálculo de splines
+fix(integracion): validar número de intervalos
+docs(docs): agregar guía de contribución
+test(no-lineales): añadir pruebas para secante
+refactor(utils): simplificar validaciones
+ci(ci): actualizar flujo de GitHub Actions
+
+
+---
+
+## Ejemplos incorrectos
+
+### Incorrecto
+
+text
+arreglos varios
+
+
+### Correcto
+
+text
+fix(utils): corregir validaciones
+
+
+### Incorrecto
+
+text
+nuevo metodo
+
+
+### Correcto
+
+text
+feat(no-lineales): implementar método de Müller
+
+
+### Incorrecto
+
+text
+documentacion
+
+
+### Correcto
+
+text
+docs(docs): actualizar manual de usuario
+
+
+### Incorrecto
+
+text
+cambios
+
+
+### Correcto
+
+text
+refactor(lineales): mejorar estructura interna
+
+
+### Incorrecto
+
+text
+test
+
+
+### Correcto
+
+text
+test(interpolacion): agregar pruebas para Lagrange
+
+
+---
+
+## Recomendaciones
+
+* Utilizar siempre el formato Conventional Commits.
+* Mantener descripciones breves y claras.
+* Seleccionar el ámbito adecuado.
+* Evitar mensajes genéricos.
+* Escribir los mensajes en infinitivo.
+*


### PR DESCRIPTION
## ¿Qué hace este PR?
Agrega el archivo docs/estilo-commits.md con la documentación de las convenciones de commits utilizadas en el proyecto Trazo.

Incluye:

* Formato de Conventional Commits
* Tipos de commits soportados
* Tabla de ámbitos recomendados
* 8 ejemplos correctos
* 5 ejemplos incorrectos con su corrección
* Recomendaciones de uso


## Issue relacionado
Closes #304

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [x] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
Se agregó el archivo docs/estilo-commits.md.