### PR TITLE
chore(test): configurar cobertura de Jest al 70%

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -2,4 +2,19 @@ module.exports = {
   testEnvironment: 'node',
   testMatch: ['**/tests/**/*.test.js'],
   transform: {},
+
+  collectCoverage: true,
+  coverageDirectory: 'coverage/',
+  collectCoverageFrom: [
+    'src/**/*.js',
+    '!src/index.js',
+  ],
+  coverageThreshold: {
+    global: {
+      branches: 70,
+      functions: 70,
+      lines: 70,
+      statements: 70,
+    },
+  },
 };

--- a/package.json
+++ b/package.json
@@ -10,6 +10,7 @@
     "build": "rollup -c",
     "test": "jest --config=\"{\\\"testMatch\\\":[\\\"**/*.test.js\\\"]}\"",
     "test:watch": "jest --watch tests",
+    "test:cov": "jest --coverage",
     "lint": "eslint src tests",
     "format": "prettier --write src tests"
   },


### PR DESCRIPTION
## ¿Qué hace este PR?

* Agrega configuración de cobertura en jest.config.js.
* Habilita collectCoverage y define el directorio de salida coverage/.
* Configura la recolección de cobertura para los archivos de src/, excluyendo src/index.js.
* Establece un umbral mínimo global del 70% para branches, functions, lines y statements.
* Agrega el script test:cov en package.json para ejecutar Jest con cobertura.

## Issue relacionado
Closes #274 

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [x] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas

* Se añadió la configuración de cobertura en jest.config.js.
* Se agregó el script npm run test:cov en package.json.
* La cobertura global ahora requiere un mínimo del 70% para que la ejecución sea considerada exitosa.
* No se modificaron archivos de código fuente, únicamente archivos de configuración.