### PR TITLE
test: agregar casos de borde para biseccion

### DIFF
--- a/tests/automatizados/unit/biseccion.test.js
+++ b/tests/automatizados/unit/biseccion.test.js
@@ -1,0 +1,59 @@
+import { biseccion } from '../../../src/no-lineales/biseccion.js';
+
+describe('biseccion - casos de borde', () => {
+  test('encuentra la raíz de x² - 4 en [0,3]', () => {
+    const f = (x) => x * x - 4;
+
+    const res = biseccion({
+      f,
+      a: 0,
+      b: 3,
+      tolerancia: 1e-6
+    });
+
+    expect(res.convergio).toBe(true);
+    expect(res.resultado).toBeCloseTo(2, 5);
+  });
+
+  test('intervalo sin cambio de signo lanza error', () => {
+    const f = (x) => x * x + 1;
+
+    expect(() =>
+      biseccion({
+        f,
+        a: 0,
+        b: 3
+      })
+    ).toThrow();
+  });
+
+  test('tolerancia 1e-10 produce resultado preciso', () => {
+    const f = (x) => x * x - 4;
+
+    const res = biseccion({
+      f,
+      a: 0,
+      b: 3,
+      tolerancia: 1e-10
+    });
+
+    expect(res.resultado).toBeCloseTo(2, 9);
+  });
+
+  test('las iteraciones contienen a, b, c y fc', () => {
+    const f = (x) => x * x - 4;
+
+    const res = biseccion({
+      f,
+      a: 0,
+      b: 3
+    });
+
+    const iteracion = res.iteraciones[0];
+
+    expect(iteracion).toHaveProperty('a');
+    expect(iteracion).toHaveProperty('b');
+    expect(iteracion).toHaveProperty('c');
+    expect(iteracion).toHaveProperty('fc');
+  });
+});


### PR DESCRIPTION
## ¿Qué hace este PR?

Agrega pruebas unitarias para el método de bisección cubriendo:

* Cálculo de raíz para f(x)=x²-4
* Intervalo sin cambio de signo
* Tolerancia 1e-10
* Validación de estructura de iteraciones

## Issue relacionado
Closes #276 

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [x] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [x] Agregué tests si corresponde

## Evidencia / capturas

* Captura del archivo `tests/automatizados/unit/biseccion.test.js`
* Captura de `git status` mostrando únicamente el nuevo archivo agregado