### PR TITLE
Fix docs/precision errores relativo aproximado

### DIFF
--- a/docs/precision-y-errores.md
+++ b/docs/precision-y-errores.md
@@ -39,6 +39,45 @@ E_r = |(2.003 - 1.990) / 2.003| × 100% ≈ 0.649%
 ```
 
 ---
+## Error relativo aproximado
+
+## Error relativo aproximado
+
+El **error relativo aproximado** mide la diferencia entre dos aproximaciones consecutivas cuando no se conoce el valor real de la solucion. Es uno de los errores mas utilizados en metodos iterativos.
+
+```
+E_ra = |x_nuevo - x_viejo| / |x_nuevo|
+
+```
+
+Donde:
+
+- `x_nuevo` es la aproximacion actual.
+- `x_viejo` es la aproximacion obtenida en la iteracion anterior.
+
+**¿Cuando se utiliza?**
+
+Se utiliza principalmente en metodos iterativos como biseccion, Newton-Raphson, secante y punto fijo, donde el valor exacto de la solucion generalmente es desconocido.
+
+**Relacion con el criterio de parada**
+
+El error relativo aproximado suele emplearse como criterio de convergencia. El metodo continua iterando hasta que:
+```
+E_ra < tolerancia
+```
+
+Cuando esta condicion se cumple, se considera que la aproximacion alcanzada tiene la precision requerida.
+
+**Ejemplo:**
+Si en dos iteraciones consecutivas del metodo de biseccion se obtienen los valores `1.5000` y `1.5625`, entonces:
+```
+E_ra = |1.5625 - 1.5000| / |1.5625|
+E_ra = 0.04
+```
+
+Por lo tanto, el error relativo aproximado es `0.04` (4%).
+
+---
 
 ## Criterio de convergencia
 

--- a/docs/precision-y-errores.md
+++ b/docs/precision-y-errores.md
@@ -41,8 +41,6 @@ E_r = |(2.003 - 1.990) / 2.003| × 100% ≈ 0.649%
 ---
 ## Error relativo aproximado
 
-## Error relativo aproximado
-
 El **error relativo aproximado** mide la diferencia entre dos aproximaciones consecutivas cuando no se conoce el valor real de la solucion. Es uno de los errores mas utilizados en metodos iterativos.
 
 ```


### PR DESCRIPTION
## ¿Qué hace este PR?

Agrega la sección de error relativo aproximado a la documentación de precisión y manejo de errores.

## Issue relacionado
Closes #341 

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [x] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas

Se agregó una nueva sección denominada **Error relativo aproximado** en `docs/precision-y-errores.md`, incluyendo:
- Definición y fórmula.
- Casos de uso en métodos iterativos.
- Relación con el criterio de parada.
- Ejemplo de cálculo aplicado al método de bisección.
<img width="1307" height="622" alt="imagen_2026-06-09_143430904" src="https://github.com/user-attachments/assets/ce7637f6-ad24-4501-bc7f-f8f68752f8c4" />
