### PR TITLE
fix: corrección de .gitignore para excluir node_modules y archivos de…

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -52,8 +52,12 @@ target/
 coverage/
 .coverage
 htmlcov/
+.nyc_output/
 
 # Datos sensibles
 *.pem
 *.key
 *.cert
+
+# Lock files (librería: no versionar)
+package-lock.json


### PR DESCRIPTION
… lock innecesarios

## ¿Qué hace este PR?
Corrige el `.gitignore` del proyecto para asegurar que archivos que no deben versionarse queden correctamente excluidos. Se agregan dos reglas faltantes:

- `.nyc_output/` — directorio generado por la herramienta de cobertura nyc/Istanbul.
- `package-lock.json` — al tratarse de una librería, el lock file no debe versionarse ya que cada consumidor genera el suyo propio.

No se eliminó ninguna regla existente.

## Issue relacionado
Closes #199 

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [x] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas