### PR TITLE
feat(matricial): implementar determinante_sarrus.js

### DIFF
--- a/src/matricial/determinante_sarrus.js
+++ b/src/matricial/determinante_sarrus.js
@@ -1,0 +1,21 @@
+export function determinanteSarrus(A) {
+  if (
+    !Array.isArray(A) ||
+    A.length !== 3 ||
+    A.some(fila => !Array.isArray(fila) || fila.length !== 3)
+  ) {
+    throw new Error('La matriz debe ser 3x3');
+  }
+
+  const principal =
+    A[0][0] * A[1][1] * A[2][2] +
+    A[0][1] * A[1][2] * A[2][0] +
+    A[0][2] * A[1][0] * A[2][1];
+
+  const secundaria =
+    A[0][2] * A[1][1] * A[2][0] +
+    A[0][0] * A[1][2] * A[2][1] +
+    A[0][1] * A[1][0] * A[2][2];
+
+  return principal - secundaria;
+}


### PR DESCRIPTION
## ¿Qué hace este PR?
Implementa la función determinanteSarrus para calcular el determinante de matrices 3x3 mediante la regla de Sarrus.

## Issue relacionado
Closes #246

## Tipo de cambio
- [x] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
Implementación de determinante 3x3 usando la regla de Sarrus.