### PR TITLE
docs: ampliar referencias bibliográficas para algoritmos

### DIFF
--- a/docs/referencias.md
+++ b/docs/referencias.md
@@ -2,10 +2,113 @@
 
 Para el sustento teórico y la implementación de los algoritmos de este proyecto, se han consultado las siguientes fuentes bibliográficas:
 
-| No.| Autor | Titulo | Año | Editorial o URL| 
-|---|---|---|---|---|---|---| 
-| 1. | Steven C. Chapra | Métodos numéricos para ingenieros| 2015 (7ª Edición) | McGraw-Hill Education URL: https://www.mheducation.com/highered/product/numerical-methods-for-engineers-chapra.html |
-| 2. | Timothy Sauer | Análisis numérico | 2013 (2ª Edición) | Pearson Education URL: https://www.pearson.com/en-us/subject-catalog/p/numerical-analysis/P200000006340?view=educator |
-| 3. | Antonio Nieves | Métodos numéricos: aplicados a la ingeniería | 2014 (4ª Edición) | Grupo Editorial Patria URL: [enlace roto o no disponible] |
-| 4. | Richard L.Burden | Análisis Numérico | 2017 (10ª Edición) | Cengage Learning URL: https://archive.org/details/numericalanalysi0000burd_t5a0 |
-| 5. | Strang, G | Introduction to Linear Algebra | 2016 |  Wellesley Cambridge Press URL: https://math.mit.edu/~gs/linearalgebra/ | 
+| No. | Autor             | Título                                         | Año                 | Editorial o URL           |
+| --- | ----------------- | ---------------------------------------------- | ------------------- | ------------------------- |
+| 1   | Steven C. Chapra  | *Métodos Numéricos para Ingenieros*            | 2015 (7.ª edición)  | McGraw-Hill Education     |
+| 2   | Timothy Sauer     | *Análisis Numérico*                            | 2013 (2.ª edición)  | Pearson Educación         |
+| 3   | Antonio Nieves    | *Métodos Numéricos: Aplicados a la Ingeniería* | 2014 (4.ª edición)  | Grupo Editorial Patria    |
+| 4   | Richard L. Burden | *Análisis Numérico*                            | 2017 (10.ª edición) | Cengage Learning          |
+| 5   | Gilbert Strang    | *Introduction to Linear Algebra*               | 2016                | Wellesley-Cambridge Press |
+
+---
+
+## Referencias por Método
+
+A continuación se detallan las referencias específicas para cada algoritmo implementado en el proyecto.
+
+---
+
+### 1. Método de Bisección
+
+| Campo | Detalle |
+|---|---|
+| **Autor** | Burden, R. L. & Faires, J. D. |
+| **Título** | Análisis Numérico |
+| **Edición** | 10ª Edición |
+| **Editorial** | Cengage Learning |
+| **Año** | 2017 |
+| **Capítulo** | Capítulo 2 — Solución de ecuaciones en una variable |
+| **Páginas** | pp. 48–54 |
+
+---
+
+### 2. Método de Newton-Raphson
+
+| Campo | Detalle |
+|---|---|
+| **Autor** | Burden, R. L. & Faires, J. D. |
+| **Título** | Análisis Numérico |
+| **Edición** | 10ª Edición |
+| **Editorial** | Cengage Learning |
+| **Año** | 2017 |
+| **Capítulo** | Capítulo 2 — Solución de ecuaciones en una variable |
+| **Páginas** | pp. 67–75 |
+
+---
+
+### 3. Método de Gauss-Seidel
+
+| Campo | Detalle |
+|---|---|
+| **Autor** | Burden, R. L. & Faires, J. D. |
+| **Título** | Análisis Numérico |
+| **Edición** | 10ª Edición |
+| **Editorial** | Cengage Learning |
+| **Año** | 2017 |
+| **Capítulo** | Capítulo 7 — Métodos iterativos para la solución de sistemas lineales |
+| **Páginas** | pp. 453–462 |
+
+---
+
+### 4. Regla de Simpson (Integración Numérica)
+
+| Campo | Detalle |
+|---|---|
+| **Autor** | Chapra, S. C. & Canale, R. P. |
+| **Título** | Métodos Numéricos para Ingenieros |
+| **Edición** | 7ª Edición |
+| **Editorial** | McGraw-Hill Education |
+| **Año** | 2015 |
+| **Capítulo** | Capítulo 21 — Integración de Newton-Cotes (fórmulas cerradas) |
+| **Páginas** | pp. 574–591 |
+
+---
+
+### 5. Método de Runge-Kutta de 4to Orden (RK4)
+
+| Campo | Detalle |
+|---|---|
+| **Autor** | Chapra, S. C. & Canale, R. P. |
+| **Título** | Métodos Numéricos para Ingenieros |
+| **Edición** | 7ª Edición |
+| **Editorial** | McGraw-Hill Education |
+| **Año** | 2015 |
+| **Capítulo** | Capítulo 25 — Métodos de Runge-Kutta |
+| **Páginas** | pp. 724–740 |
+
+---
+
+### 6. Interpolación por Splines
+
+| Campo | Detalle |
+|---|---|
+| **Autor** | Chapra, S. C. & Canale, R. P. |
+| **Título** | Métodos Numéricos para Ingenieros |
+| **Edición** | 7ª Edición |
+| **Editorial** | McGraw-Hill Education |
+| **Año** | 2015 |
+| **Capítulo** | Capítulo 18 — Interpolación con splines e interpolación por partes |
+| **Páginas** | pp. 489–513 |
+
+---
+
+## Resumen de Referencias por Método
+
+| Método | Autor | Título | Capítulo | Páginas |
+|---|---|---|---|---|
+| Bisección | Burden & Faires | Análisis Numérico (10ª ed.) | Cap. 2 | pp. 48–54 |
+| Newton-Raphson | Burden & Faires | Análisis Numérico (10ª ed.) | Cap. 2 | pp. 67–75 |
+| Gauss-Seidel | Burden & Faires | Análisis Numérico (10ª ed.) | Cap. 7 | pp. 453–462 |
+| Simpson | Chapra & Canale | Métodos Numéricos para Ingenieros (7ª ed.) | Cap. 21 | pp. 574–591 |
+| Runge-Kutta 4 (RK4) | Chapra & Canale | Métodos Numéricos para Ingenieros (7ª ed.) | Cap. 25 | pp. 724–740 |
+| Splines cúbicos | Chapra & Canale | Métodos Numéricos para Ingenieros (7ª ed.) | Cap. 18 | pp. 489–513 |


### PR DESCRIPTION
## ¿Qué hace este PR?
Amplía docs/referencias.md incorporando referencias bibliográficas específicas para los algoritmos implementados en el proyecto.

Se agregan referencias para:

- Método de Bisección
- Método de Newton-Raphson
- Método de Gauss-Seidel
- Regla de Simpson
- Método de Runge-Kutta de cuarto orden (RK4)
- Interpolación por Splines

También se hizo corrección del formato de la tabla de referencias bibliográficas, para mejorar su visualización y legibilidad en Markdown.

> No se agregaron ni eliminaron referencias; únicamente se mejoró la presentación de la tabla

## Issue relacionado
Closes #328 

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [x] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [ ] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas