### PR TITLE
docs: documentar dependencias del proyecto

### DIFF
--- a/docs/dependencias.md
+++ b/docs/dependencias.md
@@ -1,0 +1,24 @@
+# Dependencias del Proyecto
+
+## Política de dependencias
+
+Este proyecto no utiliza dependencias de producción (`dependencies`). Se busca mantener el proyecto ligero y reducir dependencias innecesarias en tiempo de ejecución.
+
+Las herramientas instaladas corresponden únicamente a dependencias de desarrollo (`devDependencies`), utilizadas para pruebas, análisis de código, formateo y empaquetado.
+
+## Dependencias de Producción
+
+Actualmente no existen dependencias de producción.
+
+| Nombre | Versión | Propósito | Enlace |
+|---------|---------|---------|---------|
+| Ninguna | - | El proyecto no requiere dependencias en tiempo de ejecución. | - |
+
+## Dependencias de Desarrollo
+
+| Nombre | Versión | Propósito | Enlace |
+|---------|---------|---------|---------|
+| eslint | ^8.57.1 | Detectar errores y mantener la calidad del código. | https://eslint.org |
+| jest | ^29.7.0 | Ejecutar pruebas automatizadas. | https://jestjs.io |
+| prettier | ^3.8.3 | Formatear el código de manera consistente. | https://prettier.io |
+| rollup | ^4.0.0 | Empaquetar y generar versiones distribuidas del proyecto. | https://rollupjs.org |


### PR DESCRIPTION
## ¿Qué hace este PR?

Agrega el archivo `docs/dependencias.md` con la documentación de las dependencias del proyecto.

Se incluye:
- La política de no utilizar dependencias de producción (`dependencies`).
- Una explicación de por qué actualmente no existen dependencias de producción.
- Una tabla con las `devDependencies`, indicando nombre, versión, propósito y enlace oficial.

## Issue relacionado
Closes #309

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [x] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas

Se creó el archivo:

`docs/dependencias.md`

<img width="1722" height="757" alt="imagen_2026-06-10_221742589" src="https://github.com/user-attachments/assets/f18df7e3-cbde-444a-9fe7-f9cc5b6a7847" />
<img width="797" height="417" alt="imagen_2026-06-10_221854717" src="https://github.com/user-attachments/assets/823d3c57-6383-4498-b84b-62f0428811bb" />


