### PR TITLE
chore: documenta consolidación de lineales

### DIFF
--- a/docs/flujo-git.md
+++ b/docs/flujo-git.md
@@ -60,5 +60,5 @@ Al crear nuevos métodos, asegúrate de colocarlos en los directorios correctos 
 - Métodos de sistemas de ecuaciones lineales:
    src/lineales/metodo.js
 
->  ***Importante:*** No utilizar rutas antiguas como src/root/, src/integration/ o src/linearAlgebra/.
+>  ***Importante:*** No utilizar rutas antiguas como src/root/, src/integration/, src/linearAlgebra/, etc.
 ---


### PR DESCRIPTION
## ¿Qué hace este PR?

Actualiza documentación obsoleta relacionada con el directorio
src/linearAlgebra/.

Se verificó que determinant.js ya se encuentra en
src/lineales/determinant.js y que no existe el directorio
src/linearAlgebra/, por lo que únicamente se corrigieron
referencias antiguas en la documentación.

## Issue relacionado
Closes #262 

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [x] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [ ] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas

git grep "linearAlgebra"

Resultado:
Solo existían referencias en documentación.
No existe actualmente el directorio src/linearAlgebra/.