### PR TITLE
chore: configurar build CJS y ESM con Rollup

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,8 +2,15 @@
   "name": "trazo",
   "version": "1.0.0",
   "description": "Numerical methods library for mathematics and engineering applications",
-  "main": "src/index.js",
+  "main": "dist/trazo.cjs.js",
+  "module": "dist/trazo.esm.js",
   "type": "module",
+  "exports": {
+    ".": {
+      "require": "./dist/trazo.cjs.js",
+      "import": "./dist/trazo.esm.js"
+    }
+  },
   "scripts": {
     "start": "node src/index.js",
     "build": "rollup -c",

--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -2,14 +2,12 @@ export default {
   input: 'src/index.js',
   output: [
     {
-      file: 'dist/trazo.esm.js',
-      format: 'esm'
+      file: 'dist/trazo.cjs.js',
+      format: 'cjs'
     },
     {
-      file: 'dist/trazo.umd.js',
-      format: 'umd',
-      name: 'Trazo',
-      exports: 'named'
+      file: 'dist/trazo.esm.js',
+      format: 'esm'
     }
   ]
 };


### PR DESCRIPTION
## ¿Qué hace este PR?

Actualiza la configuración de Rollup para generar distribuciones en formato CommonJS (CJS) y ES Modules (ESM).

Cambios realizados:

* Se actualizó `rollup.config.mjs` para generar:

  * `dist/trazo.cjs.js`
  * `dist/trazo.esm.js`
* Se actualizó `package.json` para:

  * Definir `main` apuntando a la versión CJS.
  * Definir `module` apuntando a la versión ESM.
  * Agregar `exports` para soportar importación mediante `require()` e `import`.
* Se verificó que `npm run build` genera correctamente ambos archivos de salida.

## Issue relacionado

Closes #279

## Tipo de cambio

* [ ] feat — nueva funcionalidad
* [ ] fix — corrección de error
* [ ] docs — documentación
* [ ] test — pruebas
* [x] chore — configuración
* [ ] refactor — mejora sin cambio funcional
* [ ] security — seguridad
* [ ] data — análisis de datos

## Checklist

* [x] Mi código sigue los estándares del proyecto
* [ ] Actualicé la documentación correspondiente
* [x] Mis cambios no rompen funcionalidad existente
* [ ] Agregué tests si corresponde

## Evidencia / capturas

### Build ejecutado correctamente

```bash
npm run build
```

### Archivos generados

```text
dist/trazo.cjs.js
dist/trazo.esm.js
```

Se verificó la generación de ambos formatos requeridos por el issue.
