### PR TITLE
test: agregar pruebas unitarias para métodos EDO

### DIFF
--- a/tests/automatizados/unit/runge_kutta.test.js
+++ b/tests/automatizados/unit/runge_kutta.test.js
@@ -1,0 +1,71 @@
+import { euler } from '../../../src/edo/euler.js';
+import { rungeKutta4 } from '../../../src/edo/runge_kutta_4.js';
+
+describe('Métodos EDO', () => {
+  const f = (t, y) => -y;
+  const valorExacto = Math.exp(-0.1);
+
+  test('Euler aproxima y(0.1) para dy/dt = -y', () => {
+    const res = euler({
+      f,
+      x0: 0,
+      y0: 1,
+      h: 0.1,
+      xFinal: 0.1
+    });
+
+    const ultimo = res.resultado[res.resultado.length - 1];
+    const yEuler = ultimo[1];
+
+    expect(yEuler).toBeCloseTo(valorExacto, 1);
+  });
+
+  test('RK4 es más preciso que Euler para la misma EDO', () => {
+    const resEuler = euler({
+      f,
+      x0: 0,
+      y0: 1,
+      h: 0.1,
+      xFinal: 0.1
+    });
+
+    const yEuler =
+      resEuler.resultado[resEuler.resultado.length - 1][1];
+
+    const resRK4 = rungeKutta4(
+      f,
+      1,
+      0,
+      0.1,
+      0.1
+    );
+
+    const yRK4 = resRK4[resRK4.length - 1].y;
+
+    const errorEuler = Math.abs(yEuler - valorExacto);
+    const errorRK4 = Math.abs(yRK4 - valorExacto);
+
+    expect(errorRK4).toBeLessThan(errorEuler);
+  });
+
+  test('h <= 0 lanza error', () => {
+    expect(() =>
+      rungeKutta4(f, 1, 0, 1, 0)
+    ).toThrow();
+  });
+
+  test('RK4 retorna array de objetos { t, y }', () => {
+    const resultado = rungeKutta4(
+      f,
+      1,
+      0,
+      0.1,
+      0.1
+    );
+
+    expect(Array.isArray(resultado)).toBe(true);
+
+    expect(resultado[0]).toHaveProperty('t');
+    expect(resultado[0]).toHaveProperty('y');
+  });
+});


### PR DESCRIPTION
## ¿Qué hace este PR?

Agrega pruebas unitarias para métodos de EDOs.

Se incorporan casos para:

- Aproximación de Euler para la EDO dy/dt = -y con solución analítica conocida.
- Comparación de precisión entre Euler y Runge-Kutta de cuarto orden (RK4).
- Validación de errores cuando el paso h es menor o igual a cero.
- Verificación de la estructura de salida retornada por RK4.

## Issue relacionado

Closes #284

## Tipo de cambio

- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [x] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist

- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [x] Agregué tests si corresponde

## Evidencia / capturas

Ejecución de pruebas:

```text
PASS tests/casos/funcionales/runge_kutta.test.js
PASS tests/automatizados/unit/runge_kutta.test.js

Test Suites: 2 passed, 2 total
Tests:       7 passed, 7 total
Snapshots:   0 total