### PR TITLE
feat: agregar interpolacion de Newton por diferencias divididas

### DIFF
--- a/src/interpolacion/newton_diferencias.js
+++ b/src/interpolacion/newton_diferencias.js
@@ -1,0 +1,52 @@
+class NumericalError extends Error {
+  constructor(message) {
+    super(message);
+    this.name = 'NumericalError';
+  }
+}
+
+/**
+ * Calcula la interpolación de Newton por diferencias divididas.
+ *
+ * @param {number[]} xs - Valores conocidos de x.
+ * @param {number[]} ys - Valores conocidos de y.
+ * @param {number} x - Punto donde se evalúa el polinomio interpolante.
+ * @returns {number} Valor interpolado en x.
+ * @throws {NumericalError} Si xs e ys no tienen igual longitud o si hay menos de 2 puntos.
+ */
+export function newtonDiferenciasDivididas(xs, ys, x) {
+  if (!Array.isArray(xs) || !Array.isArray(ys)) {
+    throw new NumericalError('xs e ys deben ser arrays.');
+  }
+
+  if (xs.length !== ys.length) {
+    throw new NumericalError('xs e ys deben tener la misma longitud.');
+  }
+
+  if (xs.length < 2) {
+    throw new NumericalError('Se requieren al menos 2 puntos para interpolar.');
+  }
+
+  const n = xs.length;
+  const tabla = Array.from({ length: n }, () => Array(n).fill(0));
+
+  for (let i = 0; i < n; i++) {
+    tabla[i][0] = ys[i];
+  }
+
+  for (let j = 1; j < n; j++) {
+    for (let i = 0; i < n - j; i++) {
+      tabla[i][j] = (tabla[i + 1][j - 1] - tabla[i][j - 1]) / (xs[i + j] - xs[i]);
+    }
+  }
+
+  let resultado = tabla[0][0];
+  let producto = 1;
+
+  for (let i = 1; i < n; i++) {
+    producto *= x - xs[i - 1];
+    resultado += tabla[0][i] * producto;
+  }
+
+  return resultado;
+}


### PR DESCRIPTION
## ¿Qué hace este PR?

Agrega el método `newtonDiferenciasDivididas(xs, ys, x)` para interpolación de Newton por diferencias divididas.

El método:

* Calcula la tabla de diferencias divididas.
* Evalúa el polinomio interpolante en el punto `x`.
* Valida que `xs` e `ys` tengan la misma longitud.
* Valida que existan al menos 2 puntos.
* Lanza `NumericalError` con mensajes descriptivos cuando las validaciones fallan.

El archivo agregado es:

* `src/interpolacion/newton_diferencias.js`

No se modificaron archivos fuera del listado solicitado.

## Issue relacionado

Closes #239

## Tipo de cambio

* [x] feat — nueva funcionalidad
* [ ] fix — corrección de error
* [ ] docs — documentación
* [ ] test — pruebas
* [ ] chore — configuración
* [ ] refactor — mejora sin cambio funcional
* [ ] security — seguridad
* [ ] data — análisis de datos

## Checklist

* [x] Mi código sigue los estándares del proyecto
* [ ] Actualicé la documentación correspondiente
* [x] Mis cambios no rompen funcionalidad existente
* [ ] Agregué tests si corresponde

## Evidencia / capturas

Se validó que el archivo sea importable:

```bash
node -e "import('./src/interpolacion/newton_diferencias.js').then(m => console.log(typeof m.newtonDiferenciasDivididas))"
```

Resultado esperado:

```bash
function
```

Se validó con puntos de una parábola `f(x) = x²`:

```bash
node -e "import('./src/interpolacion/newton_diferencias.js').then(({ newtonDiferenciasDivididas }) => console.log(newtonDiferenciasDivididas([0, 1, 2], [0, 1, 4], 3)))"
```

Resultado esperado:

```bash
9
```

Se validó que `xs.length !== ys.length` lance error:

Se validó que `xs.length < 2` lance error:
