### PR TITLE
test: add unit tests for interpolation methods

### DIFF
--- a/tests/automatizados/unit/interpolacion.test.js
+++ b/tests/automatizados/unit/interpolacion.test.js
@@ -1,0 +1,77 @@
+import { lagrange } from '../../../src/interpolacion/lagrange.js';
+import { newtonDD } from '../../../src/interpolacion/newton-dd.js';
+
+describe('Interpolación de Lagrange', () => {
+  test('reproduce exactamente un punto de interpolación', () => {
+    const puntos = [
+      [0, 1],
+      [1, 3],
+      [2, 5]
+    ];
+
+    const res = lagrange({ puntos, x: 1 });
+
+    expect(res.resultado).toBeCloseTo(3, 10);
+    expect(res.convergio).toBe(true);
+  });
+
+  test('evalúa correctamente una parábola', () => {
+    const puntos = [
+      [0, 0],
+      [1, 1],
+      [2, 4]
+    ];
+
+    const res = lagrange({ puntos, x: 3 });
+
+    expect(res.resultado).toBeCloseTo(9, 10);
+  });
+
+  test('lanza error con menos de dos puntos', () => {
+    expect(() =>
+      lagrange({
+        puntos: [[0, 1]],
+        x: 0
+      })
+    ).toThrow();
+  });
+});
+
+describe('Interpolación de Newton DD', () => {
+  test('reproduce exactamente un punto de interpolación', () => {
+    const puntos = [
+      [0, 1],
+      [1, 3],
+      [2, 5]
+    ];
+
+    const res = newtonDD({ puntos, x: 2 });
+
+    expect(res.resultado).toBeCloseTo(5, 10);
+    expect(res.convergio).toBe(true);
+  });
+
+  test('evalúa correctamente una parábola', () => {
+    const puntos = [
+      [0, 0],
+      [1, 1],
+      [2, 4]
+    ];
+
+    const res = newtonDD({ puntos, x: 3 });
+
+    expect(res.resultado).toBeCloseTo(9, 10);
+  });
+
+  test('lanza error cuando existen x repetidas', () => {
+    expect(() =>
+      newtonDD({
+        puntos: [
+          [1, 2],
+          [1, 3]
+        ],
+        x: 1
+      })
+    ).toThrow();
+  });
+});


### PR DESCRIPTION
## ¿Qué hace este PR?

Agrega pruebas unitarias para los métodos de interpolación de Lagrange y Newton por diferencias divididas.

Se incorporan casos para:

* Verificar que los métodos reproducen exactamente puntos de interpolación.
* Validar la evaluación correcta de una parábola conocida.
* Comprobar el comportamiento ante entradas inválidas.
* Verificar que los resultados indican convergencia cuando corresponde.

## Issue relacionado
Closes #282 

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [x] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [x] Agregué tests si corresponde

## Evidencia / capturas

Se ejecutó:

npm test -- interpolacion.test.js

Resultado:

* Tests ejecutados correctamente.
* Todas las pruebas pasaron sin errores.