### PR TITLE
chore: consolidar tests — unificar test/ y tests/ en una sola estructura #263

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,18 +1,21 @@
 {
-  "name": "@sis-inf/trazo",
-  "version": "0.1.0",
+  "name": "trazo",
+  "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "@sis-inf/trazo",
-      "version": "0.1.0",
+      "name": "trazo",
+      "version": "1.0.0",
       "license": "MIT",
       "devDependencies": {
         "eslint": "^8.57.1",
         "jest": "^29.7.0",
         "prettier": "^3.8.3",
         "rollup": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=16"
       }
     },
     "node_modules/@babel/code-frame": {
@@ -1187,9 +1190,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1204,9 +1204,6 @@
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1221,9 +1218,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1238,9 +1232,6 @@
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1255,9 +1246,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1272,9 +1260,6 @@
         "loong64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1289,9 +1274,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1306,9 +1288,6 @@
         "ppc64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1323,9 +1302,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1340,9 +1316,6 @@
         "riscv64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1357,9 +1330,6 @@
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1374,9 +1344,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [
@@ -1391,9 +1358,6 @@
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "MIT",
       "optional": true,
       "os": [

--- a/tests/automatizados/unit/index.test.js
+++ b/tests/automatizados/unit/index.test.js
@@ -4,7 +4,7 @@
 
 describe('Pruebas de integración', () => {
     test('debería importar error_relativo.js correctamente', async () => {
-        const module = await import('../src/utils/error_relativo.js');
+        const module = await import('../../../src/utils/error_relativo.js');
         expect(module).toBeDefined();
         expect(typeof module.errorAbsoluto).toBe('function');
         expect(typeof module.errorRelativo).toBe('function');
@@ -13,25 +13,25 @@ describe('Pruebas de integración', () => {
     });
 
     test('errorAbsoluto(3.14159, 3.14) debería ser ~0.00159', async () => {
-        const { errorAbsoluto } = await import('../src/utils/error_relativo.js');
+        const { errorAbsoluto } = await import('../../../src/utils/error_relativo.js');
         const result = errorAbsoluto(3.14159, 3.14);
         expect(result).toBeCloseTo(0.00159, 4);
     });
 
     test('errorRelativo(1, 0.9) debería ser 0.1', async () => {
-        const { errorRelativo } = await import('../src/utils/error_relativo.js');
+        const { errorRelativo } = await import('../../../src/utils/error_relativo.js');
         const result = errorRelativo(1, 0.9);
         expect(result).toBeCloseTo(0.1, 4);
     });
 
     test('errorPorcentual(100, 95) debería ser 5', async () => {
-        const { errorPorcentual } = await import('../src/utils/error_relativo.js');
+        const { errorPorcentual } = await import('../../../src/utils/error_relativo.js');
         const result = errorPorcentual(100, 95);
         expect(result).toBe(5);
     });
 
     test('errorRelativo(0, 5) debería lanzar error', async () => {
-        const { errorRelativo } = await import('../src/utils/error_relativo.js');
+        const { errorRelativo } = await import('../../../src/utils/error_relativo.js');
         expect(() => errorRelativo(0, 5)).toThrow('El valor verdadero no puede ser 0');
     });
 });


### PR DESCRIPTION
## ¿Qué hace este PR?
crea: chore/consolidar-test-tests desde dev

Los cambios que se realizo:
Movido index.test.js a index.test.js usando git mv
Eliminado el directorio test/
Actualizados los paths de importación en el archivo movido (de ../src/utils/error_relativo.js a ../../../src/utils/error_relativo.js)
Verificado que jest.config.js ya apuntaba solo a tests 
## Issue relacionado
Closes #263 

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [x] test — pruebas
- [x] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
<img width="562" height="65" alt="image" src="https://github.com/user-attachments/assets/52382f47-6d37-4651-84c7-a396f9947483" />
