### PR TITLE
chore: agregar prettier al CI como step de format:check-#285

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,5 +31,8 @@ jobs:
       - name: Run linter
         run: npm run lint
 
+      - name: Check code formatting
+        run: npm run format:check
+
       - name: Run tests
         run: npm test

--- a/package.json
+++ b/package.json
@@ -18,7 +18,8 @@
     "test:watch": "jest --watch tests",
     "test:cov": "jest --coverage",
     "lint": "eslint src tests",
-    "format": "prettier --write src tests",
+    "format": "prettier --write src/**/*.js tests/**/*.js",
+    "format:check": "prettier --check src/**/*.js",
     "typecheck": "tsc -p jsconfig.json --noEmit"
   },
   "keywords": [


### PR DESCRIPTION
## ¿Qué hace este PR?
package.json - Agregué/actualiza dos scripts:
format: Ahora usa patrones glob src/**/*.js tests/**/*.js para formatear archivos
format:check: Nuevo script que verifica el formato sin modificar archivos (solo en src/**/*.js)
.github/workflows/ci.yml - Agrega un nuevo step en el CI:
"Check code formatting" que ejecuta npm run format:check antes de correr los tests

## Issue relacionado
Closes #285 

## Tipo de cambio
- [x] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [x] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
<img width="557" height="54" alt="image" src="https://github.com/user-attachments/assets/201c0a80-191c-49f8-ab1b-c3edcea0a9bf" />
