### PR TITLE
fix: chore: agregar .github/CODEOWNERS para asigna (#286)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,9 @@
+* = @all
+
+src/no-lineales/ = @jose-luis-fernandez
+src/lineales/ = @maria-gonzalez
+src/integracion/ = @juan-pablo-ramirez
+src/interpolacion/ = @ana-maria-sanchez
+src/edo/ = @carlos-martinez
+
+docs/ = @equipo-documentacion


### PR DESCRIPTION
Fixes #286

*Automated by REAPR*