### PR TITLE
fix: chore: agregar .github/CODEOWNERS para asigna (#286)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+src/no-lineales/   = no-lineales-reviewer
+src/lineales/      = lineales-reviewer
+src/integracion/   = integracion-reviewer
+src/interpolacion/ = interpolacion-reviewer
+src/edo/           = edo-reviewer
+docs/              = docs-reviewer
+*                 = admin-reviewer


### PR DESCRIPTION
Fixes #286

*Automated by REAPR*