### PR TITLE
fix: chore: agregar .github/CODEOWNERS para asigna (#286)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+src/no-lineales/   = core-team
+src/lineales/      = core-team
+src/integracion/   = core-team
+src/interpolacion/ = core-team
+src/edo/           = core-team
+docs/              = docs-team
+*                  = admin


### PR DESCRIPTION
Fixes #286

*Automated by REAPR*