### PR TITLE
fix: chore: agregar .github/CODEOWNERS para asigna (#286)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,8 @@
+* = @all
+
+src/no-lineales/ = @jose
+src/lineales/ = @maria
+src/integracion/ = @luis
+src/interpolacion/ = @ana
+src/edo/ = @carlos
+docs/ = @equipo-documentacion


### PR DESCRIPTION
Fixes #286

*Automated by REAPR*