### PR TITLE
fix: chore: agregar .github/CODEOWNERS para asigna (#286)

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,7 @@
+src/no-lineales/   = luciano
+src/lineales/      = carlos
+src/integracion/   = ana
+src/interpolacion/ = miguel
+src/edo/           = soledad
+docs/              = @all
+*                  = @all


### PR DESCRIPTION
Fixes #286

*Automated by REAPR*