### PR TITLE
chore: agregar archivo CODEOWNERS para asignación de revisores por módulo- #286

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,22 @@
+# CODEOWNERS - Assign reviewers by module
+
+# Linear equations methods
+src/lineales/ @erwinsaul
+
+# Non-linear equations methods
+src/no-lineales/ @erwinsaul
+
+# Integration methods
+src/integracion/ @erwinsaul
+
+# Interpolation methods
+src/interpolacion/ @erwinsaul
+
+# Ordinary differential equations
+src/edo/ @erwinsaul
+
+# Documentation
+docs/ @erwinsaul
+
+# Fallback - administrator
+* @erwinsaul


### PR DESCRIPTION
## ¿Qué hace este PR?
crea el archivo CODEOWNERS con las reglas para todos los módulos especificados en la issue:
src/lineales/ 
src/no-lineales/
src/integracion/ 
src/interpolacion/ 
src/edo/ 
docs/  
* (fallback) 

## Issue relacionado
Closes #286 

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [ ] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [ ] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
<img width="491" height="63" alt="image" src="https://github.com/user-attachments/assets/ab402ae4-3e44-420e-bfa2-e5d713ec3878" />
