### PR TITLE
docs: agregar reporte de cobertura de tests por modulo

### DIFF
--- a/docs/cobertura-tests.md
+++ b/docs/cobertura-tests.md
@@ -1,0 +1,47 @@
+# Cobertura de Tests
+
+## Estado actual
+
+La ejecución de `npm run test:cov` no pudo completarse debido a un error de configuración en `jest.config.js` relacionado con el sistema de módulos ES del proyecto. Esta situación es parte de los problemas de estructura base comunicados por el ingeniero responsable.
+
+Los porcentajes de cobertura se determinarán una vez que la configuración base sea corregida. El presente documento identifica los módulos existentes y su estado de cobertura basado en el análisis del código fuente disponible.
+
+## Tabla de cobertura por módulo
+
+| Módulo | Archivo de test | Cobertura estimada | Estado |
+|---|---|---|---|
+| biseccion | tests/automatizados/unit/biseccion.test.js | desconocida | Con tests |
+| convergencia | tests/automatizados/unit/convergencia.test.js | desconocida | Con tests |
+| float_tolerance | tests/automatizados/unit/float_tolerance.test.js | desconocida | Con tests |
+| interpolacion | tests/automatizados/unit/interpolacion.test.js | desconocida | Con tests |
+| runge_kutta | tests/automatizados/unit/runge_kutta.test.js | desconocida | Con tests |
+| validaciones | tests/automatizados/unit/validaciones.test.js | desconocida | Con tests |
+| analisis | — | 0% | Sin tests |
+| diferencias | — | 0% | Sin tests |
+| edo | — | 0% | Sin tests |
+| errors | — | 0% | Sin tests |
+| integracion | — | 0% | Sin tests |
+| lineales | — | 0% | Sin tests |
+| matricial | — | 0% | Sin tests |
+| no-lineales | — | 0% | Sin tests |
+| polinomios | — | 0% | Sin tests |
+| utils | — | 0% | Sin tests |
+
+## Módulos con cobertura menor al 60%
+
+Los siguientes módulos no tienen tests y su cobertura es **0%**:
+
+- `analisis`
+- `diferencias`
+- `edo`
+- `errors`
+- `integracion`
+- `lineales`
+- `matricial`
+- `no-lineales`
+- `polinomios`
+- `utils`
+
+## Nota
+
+La cobertura real deberá medirse una vez que la configuración de Jest sea corregida en la estructura base del proyecto.


### PR DESCRIPTION
## ¿Qué hace este PR?
Crea docs/cobertura-tests.md con tabla de módulos del proyecto, estado de cobertura por módulo e identificación de módulos con cobertura menor al 60%.

## Issue relacionado
Closes #310

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ x] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [ x] Mi código sigue los estándares del proyecto
- [ x] Actualicé la documentación correspondiente
- [x ] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
No aplica — compilación pendiente por error en jest.config.js de la estructura base.