### PR TITLE
feat(cli): agregar autocompletado bash/zsh para trazo

### DIFF
--- a/src/cli/completion.bash
+++ b/src/cli/completion.bash
@@ -1,0 +1,19 @@
+_cli_methods="init build deploy test run clean status logs help version"
+_cli_flags="--f --a --b --tolerancia --salida --tabla"
+
+_cli_complete() {
+    local curr
+    curr="${COMP_WORDS[COMP_CWORD]}"
+
+    if [[ "$curr" == --* ]]; then
+        COMPREPLY=( $(compgen -W "$_cli_flags" -- "$curr") )
+        return 0
+    fi
+
+    if [[ $COMP_CWORD -eq 1 ]]; then
+        COMPREPLY=( $(compgen -W "$_cli_methods" -- "$curr") )
+        return 0
+    fi
+}
+
+complete -F _cli_complete trazo

--- a/src/cli/completion.zsh
+++ b/src/cli/completion.zsh
@@ -1,0 +1,11 @@
+_cli_methods=(init build deploy test run clean status logs help version)
+_cli_flags=(--f --a --b --tolerancia --salida --tabla)
+
+_trazo_complete() {
+    local cur
+    cur=${words[2]}
+
+    reply=(${_cli_methods} ${_cli_flags})
+}
+
+compdef _trazo_complete trazo


### PR DESCRIPTION
## ¿Qué hace este PR?

Agrega autocompletado de shell (bash/zsh) para el CLI `trazo`, permitiendo sugerencias de comandos y flags al presionar TAB en la terminal.

## Issue relacionado
Closes #618

## Tipo de cambio
- [x] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
<img width="972" height="652" alt="imagen_2026-06-28_151704186" src="https://github.com/user-attachments/assets/02abd58c-d527-45d2-955f-5188ae752183" />
<img width="1072" height="423" alt="imagen_2026-06-28_151713943" src="https://github.com/user-attachments/assets/3a0f5bdc-3dea-4b86-8d47-c2f907b78c0d" />
