### PR TITLE
fix: eliminar variable convergio sin usar en falsa posicion

### DIFF
--- a/src/no-lineales/falsa-posicion.js
+++ b/src/no-lineales/falsa-posicion.js
@@ -24,7 +24,6 @@ export function falsaPosicion({ f, a, b, tolerancia, maxIter }) {
 
     const iteraciones = [];
     let cAnterior = null;
-    let convergio = false;
 
     for (let n = 1; n <= maxIter; n++) {
         const c = (a * fb - b * fa) / (fb - fa);
@@ -47,7 +46,6 @@ export function falsaPosicion({ f, a, b, tolerancia, maxIter }) {
         });
 
         if (Math.abs(fc) < tolerancia || (error !== null && error < tolerancia)) {
-            convergio = true;
             return crearResultado({
                 resultado: c,
                 iteraciones,


### PR DESCRIPTION
## ¿Qué hace este PR?

Elimina la variable local `convergio` sin uso en `src/no-lineales/falsa-posicion.js`.

### Cambios realizados

* Se eliminó la declaración:

  * `let convergio = false;`
* Se eliminó la asignación:

  * `convergio = true;`
* Se mantiene el retorno con:

  * `convergio: true`

No se modifica el comportamiento del método, ya que el valor retornado continúa siendo el mismo y la variable local nunca era utilizada.

## Issue relacionado
Closes #553 

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [x] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas