### PR TITLE
chore: agregar .gitattributes para forzar LF

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,0 +1,2 @@
+* text=auto eol=lf
+*.js text eol=lf


### PR DESCRIPTION
## ¿Qué hace este PR?
Agrega un archivo .gitattributes en la raíz del proyecto para forzar el uso de terminadores de línea LF en todos los archivos de texto y, específicamente, en los archivos JavaScript.

No modifica archivos existentes del proyecto, manteniendo separados los cambios de configuración de los cambios de normalización de contenido.

## Issue relacionado
Closes #673 

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [x] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas