### PR TITLE
Chore/ci verificar lockfile sincronizado

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,13 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: ${{ matrix.node-version }}
-
+      - name: Verify package-lock.json is in sync
+        run: |
+          npm install --package-lock-only
+          git diff --exit-code package-lock.json || (
+            echo "package-lock.json desincronizado, ejecuta npm install localmente y commitea el resultado"
+            exit 1
+          )
       - name: Install dependencies
         run: npm install
 


### PR DESCRIPTION
…tall

## ¿Qué hace este PR?

Agrega una verificación temprana en el pipeline de CI para asegurar que `package.json` y `package-lock.json` estén sincronizados antes de ejecutar `npm install`.

Si se detecta una desincronización, el pipeline falla inmediatamente con un mensaje claro y accionable.

## Issue relacionado
Closes #686 

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [x] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
- Caso correcto: CI pasa sin cambios
- Caso incorrecto: CI falla con mensaje explícito de desincronización