### PR TITLE
chore(build): add circular dependency detection with madge

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,9 @@ jobs:
 
       - name: Check code formatting
         run: npm run format:check
+      
+      - name: Check circular dependencies
+        run: npm run check:circular
 
       - name: Run tests
         run: npm test

--- a/package.json
+++ b/package.json
@@ -20,7 +20,8 @@
     "lint": "eslint src tests",
     "format": "prettier --write src/**/*.js tests/**/*.js",
     "format:check": "prettier --check src/**/*.js",
-    "typecheck": "tsc -p jsconfig.json --noEmit"
+    "typecheck": "tsc -p jsconfig.json --noEmit",
+	"check:circular": "madge --circular --extensions js src/"
   },
   "keywords": [
     "numerical-methods",
@@ -44,6 +45,7 @@
     "eslint": "^8.57.1",
     "jest": "^29.7.0",
     "prettier": "^3.8.3",
-    "rollup": "^4.0.0"
+    "rollup": "^4.0.0",
+	"madge": "^8.0.0"
   }
 }


### PR DESCRIPTION
## ¿Qué hace este PR?

Agrega detección de dependencias circulares en el proyecto usando madge.
- Agregado madge como dependencia de desarrollo
- Nuevo script `npm run check:circular`
- Integración del check en CI (ci.yml)
- 
## Issue relacionado
Closes #683 

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [x] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
El pipeline ahora falla si existen dependencias circulares en `src/`.