### PR TITLE
chore(ci): document cyclomatic complexity exception in splineCubicoNa…

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -16,6 +16,7 @@ export default [
     rules: {
       semi: ['error', 'always'],
       'no-unused-vars': 'warn',
+	  complexity: ['error', 15],
     },
   },
 ];

--- a/src/interpolacion/spline_cubico.js
+++ b/src/interpolacion/spline_cubico.js
@@ -15,6 +15,7 @@ import { ErrorParametros } from '../core/errores.js';
  * const res = splineCubicoNatural([0, 1, 2], [0, 1, 4], 1.5);
  * // res.resultado ≈ 2.25
  */
+// eslint-disable-next-line complexity
 export function splineCubicoNatural(xs, ys, x) {
 
     // Validaciones


### PR DESCRIPTION
## ¿Qué hace este PR?

Este PR activa la regla de complejidad ciclomática en ESLint con un umbral inicial de 15, con el objetivo de mejorar la mantenibilidad del código y detectar funciones con exceso de ramas de decisión.

Se agrega una excepción puntual en la función `splineCubicoNatural` debido a la naturaleza del algoritmo de interpolación cúbica, que requiere múltiples condiciones y casos de frontera.

## Issue relacionado
Closes #681 

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [x] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas

- ESLint rule `complexity` activada con umbral 15
- Excepción aplicada en `splineCubicoNatural` con `eslint-disable-next-line complexity`
- `npm run lint` ejecutado correctamente