### PR TITLE
chore(build): actualizar docs/dependencias.md -676

### DIFF
--- a/docs/dependencias.md
+++ b/docs/dependencias.md
@@ -2,22 +2,22 @@
 
 ## Política de dependencias
 
-Este proyecto no utiliza dependencias de producción (`dependencies`). Se busca mantener el proyecto ligero y reducir dependencias innecesarias en tiempo de ejecución.
+El proyecto procura mantener un número reducido de dependencias de producción (`dependencies`), incorporándolas únicamente cuando aportan una funcionalidad esencial y su uso está debidamente justificado.
 
-Las herramientas instaladas corresponden únicamente a dependencias de desarrollo (`devDependencies`), utilizadas para pruebas, análisis de código, formateo y empaquetado.
+Además de las dependencias de producción, el proyecto utiliza dependencias de desarrollo (`devDependencies`) destinadas a pruebas, análisis de código, formateo y empaquetado.
 
 ## Dependencias de Producción
 
-Actualmente no existen dependencias de producción.
+Actualmente el proyecto utiliza la siguiente dependencia de producción:
 
 | Nombre | Versión | Propósito | Enlace |
-|---------|---------|---------|---------|
-| Ninguna | - | El proyecto no requiere dependencias en tiempo de ejecución. | - |
+|---------|----------|-----------|--------|
+| mathjs | ^14.8.0| Parseo seguro de expresiones matemáticas representadas como cadenas (`string`) utilizadas por el CLI y el playground. Su incorporación responde a una necesidad concreta y se diferencia del uso descartado anteriormente, donde la dependencia no estaba justificada. | https://mathjs.org |
 
 ## Dependencias de Desarrollo
 
 | Nombre | Versión | Propósito | Enlace |
-|---------|---------|---------|---------|
+|---------|----------|-----------|--------|
 | eslint | ^8.57.1 | Detectar errores y mantener la calidad del código. | https://eslint.org |
 | jest | ^29.7.0 | Ejecutar pruebas automatizadas. | https://jestjs.io |
 | prettier | ^3.8.3 | Formatear el código de manera consistente. | https://prettier.io |


### PR DESCRIPTION
## ¿Qué hace este PR?

Actualiza la documentación de `docs/dependencias.md` para reflejar que el proyecto ahora utiliza **mathjs** como su primera dependencia de producción. Además, explica el propósito específico de esta dependencia para el parseo seguro de expresiones matemáticas en el CLI y el playground, diferenciando este uso del empleo previamente descartado dentro del proyecto.

## Issue relacionado

Closes #676

## Tipo de cambio

- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [x] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist

- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
<img width="1597" height="866" alt="imagen_2026-07-03_213510048" src="https://github.com/user-attachments/assets/0397e616-cc12-4ff5-beed-7a0b16539ec2" />
