### PR TITLE
feat(build): agregar generación de source maps al build de rollup

### DIFF
--- a/rollup.config.mjs
+++ b/rollup.config.mjs
@@ -3,11 +3,13 @@ export default {
   output: [
     {
       file: 'dist/trazo.cjs.js',
-      format: 'cjs'
+      format: 'cjs',
+      sourcemap: true
     },
     {
       file: 'dist/trazo.esm.js',
-      format: 'esm'
+      format: 'esm',
+      sourcemap: true
     }
   ]
 };


### PR DESCRIPTION
## ¿Qué hace este PR?

Agrega la generación de **source maps** al proceso de build de Rollup habilitando `sourcemap: true` en cada salida configurada. Esto permite que los bundles generados puedan mapearse al código fuente original durante la depuración, facilitando el análisis de errores tanto en navegadores como en Node.js.

## Issue relacionado
Closes #605

## Tipo de cambio
- [x] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
<img width="866" height="537" alt="imagen_2026-07-03_215112291" src="https://github.com/user-attachments/assets/d4508622-199b-4a2b-862a-e309cb2dbd73" />
<img width="912" height="587" alt="imagen_2026-07-03_215133829" src="https://github.com/user-attachments/assets/ae590ee5-8ffc-4471-9edb-252ea24da561" />
