### PR TITLE
feat(cli): agregar CLI ejecutable trazo

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "main": "dist/trazo.cjs.js",
   "module": "dist/trazo.esm.js",
   "type": "module",
+  "bin": {
+  "trazo": "./src/cli/trazo-cli.js"
+  },
   "exports": {
     ".": {
       "require": "./dist/trazo.cjs.js",
@@ -47,5 +50,8 @@
     "prettier": "^3.8.3",
     "rollup": "^4.0.0",
 	"madge": "^8.0.0"
+  },
+  "dependencies": {
+  "mathjs": "^15.2.0"
   }
 }

--- a/src/cli/trazo-cli.js
+++ b/src/cli/trazo-cli.js
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+
+import { compile } from "mathjs";
+import { biseccion } from "../no-lineales/biseccion.js";
+
+function parseArgs(argv) {
+  const command = argv[0];
+  const args = {};
+
+  for (let i = 1; i < argv.length; i++) {
+    const arg = argv[i];
+
+    if (arg.startsWith("--")) {
+      args[arg.slice(2)] = argv[i + 1];
+      i++;
+    }
+  }
+
+  return { command, args };
+}
+
+function parseFunction(expression) {
+  if (!expression) {
+    throw new Error("Debe proporcionar una expresión con --f");
+  }
+
+  const compiled = compile(expression);
+
+  return (x) => compiled.evaluate({ x });
+}
+
+function showHelp() {
+  console.log(`
+Trazo CLI
+
+Uso:
+  trazo <metodo> [opciones]
+
+Métodos disponibles:
+  biseccion
+
+Opciones para biseccion:
+  --f              Función (ej: "x^2-4")
+  --a              Extremo izquierdo
+  --b              Extremo derecho
+  --tolerancia     Tolerancia (opcional)
+  --maxIter        Máximo de iteraciones (opcional)
+
+Ejemplo:
+  trazo biseccion --f "x^2-4" --a 0 --b 3
+`);
+}
+
+const { command, args } = parseArgs(process.argv.slice(2));
+
+if (
+  !command ||
+  command === "--help" ||
+  process.argv.includes("--help") ||
+  process.argv.includes("-h")
+) {
+  showHelp();
+  process.exit(0);
+}
+
+try {
+  switch (command) {
+    case "biseccion": {
+      if (!args.f || args.a === undefined || args.b === undefined) {
+        throw new Error(
+          "Debe proporcionar --f, --a y --b."
+        );
+      }
+
+      const resultado = biseccion({
+        f: parseFunction(args.f),
+        a: Number(args.a),
+        b: Number(args.b),
+        tolerancia:
+          args.tolerancia !== undefined
+            ? Number(args.tolerancia)
+            : undefined,
+        maxIter:
+          args.maxIter !== undefined
+            ? Number(args.maxIter)
+            : undefined,
+      });
+
+      console.log(JSON.stringify(resultado, null, 2));
+      break;
+    }
+
+    default:
+      console.error(`Método '${command}' no soportado.\n`);
+      showHelp();
+      process.exit(1);
+  }
+} catch (error) {
+  console.error("Error:", error.message);
+  process.exit(1);
+}


### PR DESCRIPTION
## ¿Qué hace este PR?
Este PR agrega un CLI ejecutable llamado `trazo` que permite invocar métodos numéricos directamente desde la línea de comandos.

Se introduce el archivo `src/cli/trazo-cli.js`, que funciona como punto de entrada mediante el campo `bin` en `package.json`, permitiendo ejecutar el método `biseccion` desde la terminal sin necesidad de escribir código JavaScript adicional.

## Issue relacionado
Closes #613 

## Tipo de cambio
- [x ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
<img width="791" height="913" alt="imagen_2026-07-04_235313998" src="https://github.com/user-attachments/assets/394fcfc3-a503-45f6-a9b2-95acabebcd65" />
<img width="672" height="817" alt="imagen_2026-07-04_235345644" src="https://github.com/user-attachments/assets/87e696dd-0f0d-4b9b-aa5f-97886e091d1f" />
