### PR TITLE
feat(cli): crear CLI ejecutable trazo

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,9 @@
   "main": "dist/trazo.cjs.js",
   "module": "dist/trazo.esm.js",
   "type": "module",
+  "bin": {
+    "trazo": "./src/cli/trazo-cli.js"
+  },
   "exports": {
     ".": {
       "require": "./dist/trazo.cjs.js",

--- a/src/cli/trazo-cli.js
+++ b/src/cli/trazo-cli.js
@@ -1,0 +1,105 @@
+#!/usr/bin/env node
+
+import { compile } from "mathjs";
+import { biseccion } from "../no-lineales/biseccion.js";
+
+function parseArgs(argv) {
+    const command = argv[0];
+    const args = {};
+
+    for (let i = 1; i < argv.length; i++) {
+        const arg = argv[i];
+
+        if (arg.startsWith("--")) {
+            args[arg.slice(2)] = argv[i + 1];
+            i++;
+        }
+    }
+
+    return { command, args };
+}
+
+function parseFunction(expression) {
+    if (!expression) {
+        throw new Error("Debe proporcionar una expresión con --f.");
+    }
+
+    try {
+        const compiled = compile(expression);
+        return (x) => compiled.evaluate({ x });
+    } catch {
+        throw new Error("Expresión matemática inválida.");
+    }
+}
+
+function showHelp() {
+    console.log(`
+Trazo CLI
+---------
+
+Uso:
+  trazo <metodo> [opciones]
+
+Métodos disponibles:
+  biseccion
+
+Opciones para biseccion:
+  --f             Función (ej: "x^2-4")
+  --a             Extremo izquierdo
+  --b             Extremo derecho
+  --tolerancia    Tolerancia (opcional)
+  --maxIter       Máximo de iteraciones (opcional)
+
+Ejemplo:
+  trazo biseccion --f "x^2-4" --a 0 --b 3
+`);
+}
+
+const { command, args } = parseArgs(process.argv.slice(2));
+
+if (
+    !command ||
+    process.argv.includes("--help") ||
+    process.argv.includes("-h")
+) {
+    showHelp();
+    process.exit(0);
+}
+
+try {
+    switch (command) {
+        case "biseccion":
+            if (
+                args.f === undefined ||
+                args.a === undefined ||
+                args.b === undefined
+            ) {
+                throw new Error("Debe proporcionar --f, --a y --b.");
+            }
+
+            const resultado = biseccion({
+                f: parseFunction(args.f),
+                a: Number(args.a),
+                b: Number(args.b),
+                tolerancia:
+                    args.tolerancia !== undefined
+                        ? Number(args.tolerancia)
+                        : undefined,
+                maxIter:
+                    args.maxIter !== undefined
+                        ? Number(args.maxIter)
+                        : undefined,
+            });
+
+            console.log(JSON.stringify(resultado, null, 2));
+            break;
+
+        default:
+            console.error(`Método "${command}" no soportado.\n`);
+            showHelp();
+            process.exit(1);
+    }
+} catch (error) {
+    console.error("Error:", error.message);
+    process.exit(1);
+}


### PR DESCRIPTION
## ¿Qué hace este PR?

Agrega un CLI ejecutable (`trazo`) que permite invocar el método de bisección desde la línea de comandos. También registra el ejecutable mediante el campo `bin` en `package.json` y añade un comando `--help` para mostrar el uso del CLI.

## Issue relacionado

Closes #613

## Tipo de cambio

- [x] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist

- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
<img width="673" height="382" alt="imagen_2026-07-06_193830306" src="https://github.com/user-attachments/assets/3ca0c8dd-81c9-4d7a-9f5e-40e81885db6c" />
<img width="691" height="615" alt="imagen_2026-07-06_193926423" src="https://github.com/user-attachments/assets/bdff9de2-5434-44e5-baed-58be8401b083" />
