### PR TITLE
feat(core): agregar timeout configurable para métodos iterativos

### DIFF
--- a/src/core/errores.js
+++ b/src/core/errores.js
@@ -41,3 +41,14 @@ export class ErrorTamano extends Error {
     this.name = "ErrorTamano";
   }
 }
+
+/**
+ * Error cuando un método iterativo excede el tiempo máximo de ejecución configurado.
+ * @example throw new ErrorTimeout("Bisección excedió el timeout de 500ms después de 42 iteraciones.");
+ */
+export class ErrorTimeout extends Error {
+  constructor(mensaje) {
+    super(mensaje);
+    this.name = "ErrorTimeout";
+  }
+}

--- a/src/no-lineales/biseccion.js
+++ b/src/no-lineales/biseccion.js
@@ -1,5 +1,5 @@
 import { crearResultado } from "../core/contrato.js";
-import { ErrorParametros } from "../core/errores.js";
+import { ErrorParametros, ErrorTimeout } from "../core/errores.js";
 import {
   validarFuncion,
   validarIntervalo,
@@ -16,6 +16,7 @@ import {
  * @param {number} parametros.b - Extremo derecho del intervalo inicial.
  * @param {number} [parametros.tolerancia=1e-6] - Criterio de parada basado en el error absoluto.
  * @param {number} [parametros.maxIter=100] - Número máximo de iteraciones permitidas.
+ * @param {number|null} [parametros.timeoutMs=null] - Tiempo máximo de ejecución en milisegundos.
  * @returns {{
  *   resultado: number,
  *   iteraciones: Array<{
@@ -36,18 +37,28 @@ import {
  *       a: number,
  *       b: number,
  *       tolerancia: number,
- *       maxIter: number
+ *       maxIter: number,
+ *       timeoutMs: number|null
  *     },
  *     tiempo_ms: number
  *   }
  * }} Objeto de resultado siguiendo el contrato de Trazo.
  * @throws {ErrorParametros} Si la función no es válida, el intervalo es inválido, la tolerancia o el máximo de iteraciones no son válidos, o si f(a) · f(b) >= 0.
+ * @throws {ErrorTimeout} Si se excede el tiempo máximo de ejecución configurado.
  */
-function biseccion({ f, a, b, tolerancia = 1e-6, maxIter = 100 }) {
+function biseccion({ f, a, b, tolerancia = 1e-6, maxIter = 100, timeoutMs = null }) {
   validarFuncion(f, "f");
   validarIntervalo(a, b);
   validarTolerancia(tolerancia);
   validarIteraciones(maxIter);
+
+  if (timeoutMs !== null) {
+    if (typeof timeoutMs !== "number" || !isFinite(timeoutMs) || timeoutMs <= 0) {
+      throw new ErrorParametros(
+        `Trazo.biseccion: 'timeoutMs' debe ser un número finito mayor a cero o null. Se recibió: ${timeoutMs}.`
+      );
+    }
+  }
 
   if (f(a) * f(b) >= 0) {
     throw new ErrorParametros(
@@ -63,7 +74,18 @@ function biseccion({ f, a, b, tolerancia = 1e-6, maxIter = 100 }) {
   const iteraciones = [];
   let convergio = false;
 
+  const inicio = timeoutMs !== null ? performance.now() : null;
+  const INTERVALO_VERIFICACION = 10;
+
   for (let n = 0; n < maxIter; n++) {
+    if (timeoutMs !== null && n % INTERVALO_VERIFICACION === 0) {
+      if (performance.now() - inicio > timeoutMs) {
+        throw new ErrorTimeout(
+          `Trazo.biseccion: excedió el timeout de ${timeoutMs}ms después de ${n} iteraciones.`
+        );
+      }
+    }
+
     c = (izq + der) / 2;
 
     const fa = f(izq);
@@ -94,7 +116,7 @@ function biseccion({ f, a, b, tolerancia = 1e-6, maxIter = 100 }) {
       : `Se alcanzó el máximo de ${maxIter} iteraciones sin converger.`,
     meta: {
       metodo: "biseccion",
-      parametros: { a, b, tolerancia, maxIter },
+      parametros: { a, b, tolerancia, maxIter, timeoutMs },
       tiempo_ms: 0,
     },
   });

--- a/src/no-lineales/newton-raphson.js
+++ b/src/no-lineales/newton-raphson.js
@@ -1,7 +1,7 @@
 // METODO DE NEWTON-RAPHSON
 
 import { crearResultado, medirTiempo } from "../core/contrato.js";
-import { ErrorDominio } from "../core/errores.js";
+import { ErrorDominio, ErrorParametros, ErrorTimeout } from "../core/errores.js";
 import {
   validarFuncion,
   validarNumero,
@@ -18,7 +18,9 @@ import {
  * @param {number} opciones.x0 Aproximación inicial.
  * @param {number} [opciones.tolerancia=1e-6]
  * @param {number} [opciones.maxIter=100]
+ * @param {number|null} [opciones.timeoutMs=null] - Tiempo máximo de ejecución en milisegundos.
  * @returns {Object} Resultado siguiendo el contrato de Trazo.
+ * @throws {ErrorTimeout} Si se excede el tiempo máximo de ejecución configurado.
  */
 function newtonRaphson({
   f,
@@ -26,6 +28,7 @@ function newtonRaphson({
   x0,
   tolerancia = 1e-6,
   maxIter = 100,
+  timeoutMs = null,
 }) {
   validarFuncion(f, "f");
   validarFuncion(df, "df");
@@ -33,12 +36,31 @@ function newtonRaphson({
   validarTolerancia(tolerancia);
   validarIteraciones(maxIter);
 
+  if (timeoutMs !== null) {
+    if (typeof timeoutMs !== "number" || !isFinite(timeoutMs) || timeoutMs <= 0) {
+      throw new ErrorParametros(
+        `Trazo.newtonRaphson: 'timeoutMs' debe ser un número finito mayor a cero o null. Se recibió: ${timeoutMs}.`
+      );
+    }
+  }
+
   const { valor, tiempo_ms } = medirTiempo(() => {
     let x = x0;
     const iteraciones = [];
     let convergio = false;
 
+    const inicio = timeoutMs !== null ? performance.now() : null;
+    const INTERVALO_VERIFICACION = 5;
+
     for (let n = 1; n <= maxIter; n++) {
+      if (timeoutMs !== null && (n - 1) % INTERVALO_VERIFICACION === 0) {
+        if (performance.now() - inicio > timeoutMs) {
+          throw new ErrorTimeout(
+            `Trazo.newtonRaphson: excedió el timeout de ${timeoutMs}ms después de ${n - 1} iteraciones.`
+          );
+        }
+      }
+
       const fx = f(x);
       const dfx = df(x);
 
@@ -88,6 +110,7 @@ function newtonRaphson({
         x0,
         tolerancia,
         maxIter,
+        timeoutMs,
       },
       tiempo_ms,
     },


### PR DESCRIPTION
## ¿Qué hace este PR?
Agrega un mecanismo de timeout configurable para métodos iterativos de larga duración en Trazo.

- **Nuevo error `ErrorTimeout`** en `src/core/errores.js` para indicar cuando un método excede el tiempo máximo de ejecución.
- **Parámetro `timeoutMs`** (default `null`) en:
  - `biseccion()`: verificación cada 10 iteraciones
  - `newtonRaphson()`: verificación cada 5 iteraciones
- Cuando `timeoutMs` es `null`, no hay overhead ni cambio de comportamiento.
- Validación de `timeoutMs`: debe ser número finito > 0 o `null`.

## Issue relacionado
Closes #631

## Tipo de cambio
- [x] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas