### PR TITLE
chore(build): agregar campo files para controlar publicación en npm

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,6 +5,11 @@
   "main": "dist/trazo.cjs.js",
   "module": "dist/trazo.esm.js",
   "type": "module",
+  "files": [
+  "dist",
+  "README.md",
+  "LICENSE"
+  ],
   "bin": {
     "trazo": "./src/cli/trazo-cli.js"
   },


### PR DESCRIPTION
## ¿Qué hace este PR?

Agrega el campo `files` a `package.json` para controlar explícitamente
qué se incluye al publicar a **npm**, evitando que `tests/`, `docs/` y archivos
de configuración de desarrollo se publiquen accidentalmente.

### Verificación con npm pack --dry-run

| | Antes | Después |
|---|---|---|
| Archivos | todo el repo (~76+ .js) | 5 archivos |
| Tamaño empaquetado | ~estimado 300kB+ | 5.1 kB |
| Tamaño desempaquetado | — | 12.2 kB |

**Archivos en el tarball tras el cambio:**
- `LICENSE` (1.1kB) — explícito en `files`
- `README.md` (5.9kB) — explícito en `files`
- `package.json` (1.6kB) — siempre incluido por npm automáticamente
- `src/cli/trazo-cli.js` (2.4kB) — incluido por npm porque está declarado en el campo `bin`
- `src/README.md` (1.2kB) — incluido por npm automáticamente al encontrar READMEs

**Nota:** `dist/` no aparece porque aún no existe en el repo
(se genera con `npm run build` antes de publicar). Una vez buildeado
aparecerá correctamente en el tarball.

## Issue relacionado
Closes #675 

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [x] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [ ] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas

Antes:

<img width="1644" height="1268" alt="image" src="https://github.com/user-attachments/assets/4a96fcf5-0634-4017-8cee-7828ff9cf595" />

Después: 

<img width="1156" height="722" alt="image" src="https://github.com/user-attachments/assets/4d715bbb-a075-464e-bf2b-4c817112e681" />
