### PR TITLE
chore: agregar CODEOWNERS para asignación automática de revisores

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,22 +1,22 @@
-# CODEOWNERS - Assign reviewers by module
+# CODEOWNERS - Asignación automática de revisores por módulo
 
-# Linear equations methods
-src/lineales/ @erwinsaul
+# Métodos de ecuaciones lineales
+src/lineales/ @deviamamani
 
-# Non-linear equations methods
-src/no-lineales/ @erwinsaul
+# Métodos de ecuaciones no lineales
+src/no-lineales/ @deviamamani
 
-# Integration methods
-src/integracion/ @erwinsaul
+# Métodos de integración
+src/integracion/ @deviamamani
 
-# Interpolation methods
-src/interpolacion/ @erwinsaul
+# Métodos de interpolación
+src/interpolacion/ @deviamamani
 
-# Ordinary differential equations
-src/edo/ @erwinsaul
+# Métodos de ecuaciones diferenciales ordinarias
+src/edo/ @deviamamani
 
-# Documentation
-docs/ @erwinsaul
+# Documentación
+docs/ @deviamamani
 
-# Fallback - administrator
-* @erwinsaul
+# Owner por defecto del repositorio
+* @deviamamani


### PR DESCRIPTION
## ¿Qué hace este PR?
Agrega el archivo CODEOWNERS dentro de la carpeta .github para permitir la asignación automática de revisores en los Pull Requests del repositorio.

Se configuraron responsables por módulos y un owner por defecto para el proyecto.

## Issue relacionado
Closes #672

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [x] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
Se agregó .github/CODEOWNERS para definir revisores automáticos del repositorio.