### PR TITLE
feat(integracion-externa): agregar notebook Jupyter con métodos no lineales

### DIFF
--- a/examples/jupyter/metodos-no-lineales.ipynb
+++ b/examples/jupyter/metodos-no-lineales.ipynb
@@ -1,0 +1,72 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Métodos no lineales usando trazo\n",
+    "\n",
+    "Ejemplo de uso de la librería trazo dentro de Jupyter utilizando un kernel de JavaScript."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Instalación\n",
+    "\n",
+    "Para ejecutar este notebook se requiere tener configurado un kernel JavaScript como IJavascript."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import { biseccion } from 'trazo';"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Método de bisección\n",
+    "\n",
+    "Se define una función no lineal y se calcula su raíz utilizando trazo."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "const funcion = (x) => x * x - 4;\n",
+    "\n",
+    "const resultado = biseccion(funcion, 0, 5);\n",
+    "\n",
+    "resultado.raiz;"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "El resultado obtenido representa una aproximación de la raíz encontrada mediante el método numérico."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "JavaScript",
+   "language": "javascript",
+   "name": "javascript"
+  },
+  "language_info": {
+   "name": "javascript"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}


### PR DESCRIPTION
## ¿Qué hace este PR?
Agrega un ejemplo de integración de trazo dentro de Jupyter mediante un notebook con kernel de JavaScript.

Se creó el archivo `examples/jupyter/metodos-no-lineales.ipynb` incluyendo ejemplos de ejecución de métodos no lineales y explicación mediante celdas Markdown.

## Issue relacionado
Closes #641

## Tipo de cambio
- [x] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
Se agregó el notebook solicitado en `examples/jupyter/` con ejemplos ejecutables usando JavaScript en Jupyter.