### PR TITLE
feat(integracion-externa): completar notebook Jupyter con métodos numéricos

### DIFF
--- a/examples/jupyter/metodos-no-lineales.ipynb
+++ b/examples/jupyter/metodos-no-lineales.ipynb
@@ -1,0 +1,72 @@
+{
+ "cells": [
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Métodos no lineales usando trazo\n",
+    "\n",
+    "Ejemplo de uso de la librería trazo dentro de Jupyter utilizando un kernel de JavaScript."
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Instalación\n",
+    "\n",
+    "Para ejecutar este notebook se requiere tener configurado un kernel JavaScript como IJavascript."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "import { biseccion } from 'trazo';"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Método de bisección\n",
+    "\n",
+    "Se define una función no lineal y se calcula su raíz utilizando trazo."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "const funcion = (x) => x * x - 4;\n",
+    "\n",
+    "const resultado = biseccion(funcion, 0, 5);\n",
+    "\n",
+    "resultado.raiz;"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "El resultado obtenido representa una aproximación de la raíz encontrada mediante el método numérico."
+   ]
+  }
+ ],
+ "metadata": {
+  "kernelspec": {
+   "display_name": "JavaScript",
+   "language": "javascript",
+   "name": "javascript"
+  },
+  "language_info": {
+   "name": "javascript"
+  }
+ },
+ "nbformat": 4,
+ "nbformat_minor": 5
+}

--- a/examples/jupyter/metodos-no-lineales.ipynb
+++ b/examples/jupyter/metodos-no-lineales.ipynb
@@ -4,18 +4,18 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Métodos no lineales usando trazo\n",
+    "# Ejemplos de métodos numéricos usando trazo en Jupyter\n",
     "\n",
-    "Ejemplo de uso de la librería trazo dentro de Jupyter utilizando un kernel de JavaScript."
+    "Notebook de ejemplo ejecutando la librería trazo mediante un kernel de JavaScript."
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Instalación\n",
+    "## Configuración\n",
     "\n",
-    "Para ejecutar este notebook se requiere tener configurado un kernel JavaScript como IJavascript."
+    "Para ejecutar los ejemplos se requiere Jupyter con un kernel JavaScript instalado como IJavascript."
    ]
   },
   {
@@ -24,16 +24,16 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import { biseccion } from 'trazo';"
+    "import { biseccion, simpson, lagrange } from 'trazo';"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Método de bisección\n",
+    "## Método de bisección (ecuaciones no lineales)\n",
     "\n",
-    "Se define una función no lineal y se calcula su raíz utilizando trazo."
+    "El método de bisección permite encontrar raíces de funciones dividiendo repetidamente un intervalo."
    ]
   },
   {
@@ -43,17 +43,48 @@
    "outputs": [],
    "source": [
     "const funcion = (x) => x * x - 4;\n",
-    "\n",
-    "const resultado = biseccion(funcion, 0, 5);\n",
-    "\n",
-    "resultado.raiz;"
+    "const raiz = biseccion(funcion, 0, 5);\n",
+    "console.log(raiz);"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "El resultado obtenido representa una aproximación de la raíz encontrada mediante el método numérico."
+    "## Método de Simpson (integración numérica)\n",
+    "\n",
+    "El método de Simpson aproxima el valor de una integral definida usando interpolación polinómica."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "const integral = simpson(x => x*x, 0, 2, 10);\n",
+    "console.log(integral);"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "## Método de interpolación de Lagrange\n",
+    "\n",
+    "La interpolación de Lagrange permite construir una función aproximada usando puntos conocidos."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "const puntosX = [0, 1, 2];\n",
+    "const puntosY = [1, 3, 5];\n",
+    "const valor = lagrange(puntosX, puntosY, 1.5);\n",
+    "console.log(valor);"
    ]
   }
  ],


### PR DESCRIPTION
## ¿Qué hace este PR?
Completa el notebook de ejemplo para Jupyter utilizando un kernel de JavaScript.

Se actualizó el archivo `examples/jupyter/metodos-no-lineales.ipynb` agregando ejemplos de distintas categorías de métodos numéricos:

- Método de bisección para ecuaciones no lineales.
- Método de Simpson para integración numérica.
- Método de interpolación de Lagrange.

Cada ejemplo incluye una explicación mediante celdas Markdown y código JavaScript ejecutable.

## Issue relacionado
Closes #641

## Tipo de cambio
- [x] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
Se corrigió el notebook agregando tres métodos de categorías distintas como fue solicitado en la revisión anterior.