### PR TITLE
docs: agregar glosario de terminos tecnicos ingles-espanol

### DIFF
--- a/docs/glosario-ingles-espanol.md
+++ b/docs/glosario-ingles-espanol.md
@@ -1,0 +1,48 @@
+# Glosario Ingles-Espanol
+
+Tabla de terminos tecnicos en ingles que aparecen en el codigo, configuracion y documentacion del proyecto Trazo, junto a su traduccion y explicacion en espanol.
+
+## Terminos generales de JavaScript
+
+| Termino en ingles | Traduccion | Explicacion |
+|---|---|---|
+| callback | funcion de retorno | Funcion que se pasa como argumento y se ejecuta cuando termina una operacion |
+| polyfill | relleno de compatibilidad | Codigo que implementa funcionalidades modernas en navegadores antiguos |
+| bundler | empaquetador | Herramienta que combina multiples archivos JS en uno solo para produccion |
+| tree-shaking | eliminacion de codigo muerto | Proceso que elimina codigo no utilizado del bundle final |
+| side effects | efectos secundarios | Cambios que una funcion produce fuera de su propio ambito |
+| source map | mapa de fuente | Archivo que relaciona el codigo minificado con el codigo fuente original |
+| scope | ambito | Region del codigo donde una variable es accesible |
+| closure | clausura | Funcion que recuerda el ambito en el que fue creada |
+| hoisting | elevacion | Comportamiento de JS que mueve declaraciones al inicio del ambito |
+| promise | promesa | Objeto que representa el resultado futuro de una operacion asincrona |
+
+## Terminos de matematicas numericas en el codigo
+
+| Termino en ingles | Traduccion | Explicacion |
+|---|---|---|
+| bisection | biseccion | Metodo numerico para encontrar raices dividiendo intervalos |
+| interpolation | interpolacion | Estimacion de valores entre puntos conocidos |
+| convergence | convergencia | Propiedad de un metodo que se acerca al resultado correcto |
+| tolerance | tolerancia | Margen de error aceptable en calculos numericos |
+| iteration | iteracion | Repeticion de un proceso hasta cumplir una condicion |
+| derivative | derivada | Tasa de cambio de una funcion en un punto |
+| matrix | matriz | Arreglo bidimensional de numeros |
+| determinant | determinante | Valor escalar calculado a partir de una matriz cuadrada |
+| eigenvalue | valor propio | Escalar asociado a una transformacion lineal |
+| regression | regresion | Ajuste de una curva a un conjunto de datos |
+
+## Terminos de herramientas y configuracion
+
+| Termino en ingles | Traduccion | Explicacion |
+|---|---|---|
+| rollup | empaquetador | Herramienta de empaquetado usada en este proyecto (rollup.config.mjs) |
+| benchmark | prueba de rendimiento | Medicion del tiempo de ejecucion de funciones |
+| eslint | linter de JS | Herramienta que analiza el codigo en busca de errores de estilo |
+| prettier | formateador | Herramienta que formatea el codigo automaticamente |
+| coverage | cobertura | Porcentaje del codigo que esta cubierto por tests |
+| build | compilacion | Proceso de transformar el codigo fuente en archivos listos para produccion |
+| deploy | despliegue | Publicacion de la aplicacion en un servidor |
+| merge | fusion | Union de dos ramas de Git en una sola |
+| pull request | solicitud de fusion | Propuesta de cambios para integrar al repositorio oficial |
+| upstream | repositorio original | Repositorio oficial del que se hizo fork |


### PR DESCRIPTION
## ¿Qué hace este PR?
Crea docs/glosario-ingles-espanol.md con tabla de términos técnicos en inglés usados en el código, configuración y documentación del proyecto, junto a su traducción y explicación en español.

## Issue relacionado
Closes #730

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ x] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [ x] Mi código sigue los estándares del proyecto
- [ x] Actualicé la documentación correspondiente
- [ x] Mis cambios no rompen funcionalidad existente
- [ ] Agregué tests si corresponde

## Evidencia / capturas
No aplica — cambio de documentación únicamente.