### PR TITLE
chore: agregar índice general de documentación

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,7 +140,11 @@ Este contrato uniforme permite procesar el resultado de cualquier método de la 
 
 ## Documentación
 
-La documentación detallada de cada método, su fundamento matemático y ejemplos adicionales se encuentra en la carpeta [docs/](docs/).
+La documentación del proyecto se encuentra organizada en la carpeta [docs/](docs/).
+
+Para facilitar la navegación entre todas las guías y referencias disponibles, consulta el **[Índice General de Documentación](docs/indice-general.md)**.
+
+Además del índice, encontrarás documentación sobre arquitectura, métodos numéricos, ejemplos de uso, API, contribución, integración continua y despliegue.
 
 ## Contribuir
 

--- a/docs/indice-general.md
+++ b/docs/indice-general.md
@@ -2,74 +2,129 @@
 
 ## Introducción
 
-Este documento es el índice navegable maestro de toda la documentación
-del proyecto Trazo, organizado por categoría para facilitar encontrar
-la información que necesitas, ya sea que quieras usar la librería,
-entender su arquitectura, o contribuir con código.
+Este documento es el índice navegable maestro de la documentación del proyecto **Trazo**. Su objetivo es centralizar todos los documentos disponibles en la carpeta `docs/`, organizarlos por categoría y facilitar la navegación para usuarios, contribuidores y mantenedores del proyecto.
 
-> **Nota de mantenimiento:** este índice refleja los documentos
-> existentes en `docs/` al momento de su creación. Si agregas un nuevo
-> archivo `.md` a `docs/`, recuerda añadirlo también aquí en la
-> categoría correspondiente.
+Cada entrada incluye un enlace relativo al documento correspondiente y una breve descripción de su contenido.
 
 ---
 
-## 1. Arquitectura y decisiones de diseño
+# 1. Arquitectura y estándares
 
-* [arquitectura.md](arquitectura.md) — Arquitectura general del sistema y sus componentes.
-* [requerimientos.md](requerimientos.md) — Requerimientos funcionales y no funcionales del proyecto.
-* [precision-y-errores.md](precision-y-errores.md) — Consideraciones sobre precisión numérica y manejo de errores.
-* [limitaciones.md](limitaciones.md) — Limitaciones conocidas de la librería.
-
-## 2. Métodos numéricos por categoría
-
-* [metodos.md](metodos.md) — Listado general de métodos numéricos disponibles.
-* [metodos-implementados.md](metodos-implementados.md) — Estado de implementación de cada método.
-* [metodos-lineales.md](metodos-lineales.md) — Métodos para sistemas de ecuaciones lineales (Gauss, Jacobi, Gauss-Seidel, etc.).
-* [glosario-metodos-numericos.md](glosario-metodos-numericos.md) — Glosario de términos específicos de métodos numéricos.
-* [glosario.md](glosario.md) — Glosario general de términos del proyecto.
-
-## 3. Uso de la librería
-
-* [api.md](api.md) — Referencia de la API con ejemplos de uso.
-* [api-math.md](api-math.md) — Referencia matemática complementaria de la API.
-* [ejemplos.md](ejemplos.md) — Ejemplos generales de uso.
-* [ejemplos-uso.md](ejemplos-uso.md) — Ejemplos adicionales de casos de uso.
-* [casos-de-uso.md](casos-de-uso.md) — Casos de uso documentados con actor, flujo y postcondición.
-* [instalacion.md](instalacion.md) — Guía de instalación de la librería.
-* [preguntas-frecuentes.md](preguntas-frecuentes.md) — Preguntas frecuentes sobre contribución y uso del proyecto.
-
-## 4. Build y publicación
-
-* [despliegue.md](despliegue.md) — Guía de despliegue del proyecto.
-
-## 5. Contribución
-
-* [flujo-git.md](flujo-git.md) — Flujo de trabajo con Git (Forking Workflow) para contribuir.
-* [estandares-codigo.md](estandares-codigo.md) — Estándares de código a seguir en el proyecto.
-* [referencias.md](referencias.md) — Referencias y fuentes externas utilizadas.
+- [arquitectura.md](arquitectura.md) — Describe la arquitectura general del proyecto y sus componentes principales.
+- [arquitectura-decisiones.md](arquitectura-decisiones.md) — Registra decisiones técnicas relevantes tomadas durante el desarrollo.
+- [estructura-proyecto.md](estructura-proyecto.md) — Explica la organización de carpetas y archivos del repositorio.
+- [requerimientos.md](requerimientos.md) — Detalla los requerimientos funcionales y técnicos del proyecto.
+- [dependencias.md](dependencias.md) — Documenta las dependencias utilizadas por la librería.
+- [estandares-codigo.md](estandares-codigo.md) — Define lineamientos de estilo y calidad para el código fuente.
+- [convenciones-nombres-funciones.md](convenciones-nombres-funciones.md) — Establece criterios de nombres para funciones y módulos.
+- [precision-y-errores.md](precision-y-errores.md) — Explica el manejo de precisión numérica y errores computacionales.
+- [precision-flotante.md](precision-flotante.md) — Describe consideraciones sobre aritmética de punto flotante.
+- [precision-y-tolerancias-recomendadas.md](precision-y-tolerancias-recomendadas.md) — Recomienda tolerancias numéricas para distintos métodos.
+- [limitaciones.md](limitaciones.md) — Resume limitaciones generales conocidas del proyecto.
+- [limitaciones-numericas.md](limitaciones-numericas.md) — Explica limitaciones específicas de los métodos numéricos.
+- [manejo-errores.md](manejo-errores.md) — Documenta el sistema de manejo de errores.
+- [tipos-retorno.md](tipos-retorno.md) — Describe las estructuras de retorno utilizadas por los métodos.
+- [validation-inputs.md](validation-inputs.md) — Explica las validaciones aplicadas a los datos de entrada.
+- [mapa-dependencias-internas.md](mapa-dependencias-internas.md) — Presenta el mapa de dependencias internas del proyecto.
+- [roadmap.md](roadmap.md) — Muestra la planificación y evolución esperada del proyecto.
+- [seguridad-libreria.md](seguridad-libreria.md) — Documenta consideraciones de seguridad en el uso de la librería.
+- [parser-expresiones.md](parser-expresiones.md) — Explica el funcionamiento del parser de expresiones matemáticas.
+- [logging-metodos-iterativos.md](logging-metodos-iterativos.md) — Describe el sistema de registro para métodos iterativos.
 
 ---
 
-## Categorías sin documentos aún
+# 2. Guías de uso y ejemplos
 
-Las siguientes categorías están previstas para futura documentación,
-pero no tienen archivos asociados en `docs/` al momento de escribir
-este índice:
+- [indice-general.md](indice-general.md) — Índice maestro navegable de toda la documentación del proyecto.
+- [instalacion.md](instalacion.md) — Explica cómo instalar y preparar el proyecto.
+- [guia-uso-libreria.md](guia-uso-libreria.md) — Guía principal para utilizar la librería.
+- [ejemplos.md](ejemplos.md) — Presenta ejemplos básicos de uso.
+- [ejemplos-uso.md](ejemplos-uso.md) — Incluye ejemplos prácticos adicionales.
+- [casos-de-uso.md](casos-de-uso.md) — Describe casos de uso comunes del proyecto.
+- [casos-de-uso-avanzados.md](casos-de-uso-avanzados.md) — Presenta escenarios avanzados de aplicación.
+- [playground-uso.md](playground-uso.md) — Explica el uso del entorno de pruebas o playground.
+- [exportar-markdown.md](exportar-markdown.md) — Documenta cómo exportar contenido en formato Markdown.
+- [preguntas-frecuentes.md](preguntas-frecuentes.md) — Responde dudas frecuentes sobre el proyecto.
+- [errores-comunes.md](errores-comunes.md) — Enumera errores frecuentes y sus soluciones.
+- [comparacion-bibliotecas-similares.md](comparacion-bibliotecas-similares.md) — Compara Trazo con bibliotecas similares.
 
-* **CLI y herramientas de desarrollo**
-* **Playground y demos interactivas**
-* **Integraciones externas**
-* **Producción y operación**
-
-A medida que se agreguen documentos para estas categorías, deben
-incorporarse en este índice bajo el encabezado correspondiente.
 
 ---
 
-## Cómo usar este índice
+# 3. Métodos numéricos por categoría
 
-* Si buscas **cómo usar una función específica**, ve a la sección "Uso de la librería".
-* Si quieres **entender por qué un método no converge**, revisa "Métodos numéricos por categoría" o el glosario.
-* Si vas a **contribuir con código**, comienza por la sección "Contribución".
-* Si necesitas **instalar o desplegar** el proyecto, ve a "Build y publicación" e "Uso de la librería" (instalación).
+## Sistemas de ecuaciones lineales
+
+- [metodos-lineales.md](metodos-lineales.md) — Documenta métodos para resolver sistemas lineales.
+- [algebra-vectorial-matricial.md](algebra-vectorial-matricial.md) — Explica conceptos de álgebra vectorial y matricial usados en el proyecto.
+- [numero-condicion.md](numero-condicion.md) — Describe el número de condición y su importancia numérica.
+- [rendimiento-comparativo.md](rendimiento-comparativo.md) — Compara el rendimiento de distintos métodos implementados.
+
+## Ecuaciones no lineales
+
+- [metodos-no-lineales.md](metodos-no-lineales.md) — Documenta métodos para resolver ecuaciones no lineales.
+
+## Integración numérica
+
+- [integracion-numerica.md](integracion-numerica.md) — Explica métodos de integración numérica.
+- [integracion-monte-carlo.md](integracion-monte-carlo.md) — Documenta la integración mediante el método de Monte Carlo.
+
+## Interpolación
+
+- [interpolation.md](interpolation.md) — Describe métodos de interpolación disponibles en el proyecto.
+
+## Ecuaciones diferenciales ordinarias
+
+- [edo-metodos.md](edo-metodos.md) — Documenta métodos para resolver ecuaciones diferenciales ordinarias.
+
+## Información general de métodos
+
+- [metodos.md](metodos.md) — Resume los métodos numéricos del proyecto.
+- [metodos-implementados.md](metodos-implementados.md) — Lista los métodos actualmente implementados.
+- [numeros-complejos.md](numeros-complejos.md) — Explica el soporte y uso de números complejos.
+- [glosario-metodos-numericos.md](glosario-metodos-numericos.md) — Define términos relacionados con métodos numéricos.
+- [preguntas-frecuentes-matematicas.md](preguntas-frecuentes-matematicas.md) — Responde dudas frecuentes sobre conceptos matemáticos.
+
+---
+
+# 4. Referencia de API
+
+- [api.md](api.md) — Documenta la API general del proyecto.
+- [api-math.md](api-math.md) — Documenta la API matemática y sus funciones disponibles.
+
+ ---
+
+# 5. Contribución
+
+- [guia-contribuidor.md](guia-contribuidor.md) — Guía paso a paso para contribuir al proyecto.
+- [guia-agregar-metodo.md](guia-agregar-metodo.md) — Explica cómo agregar nuevos métodos numéricos.
+- [flujo-git.md](flujo-git.md) — Describe el flujo de trabajo con Git.
+- [estilo-commits.md](estilo-commits.md) — Define convenciones para escribir commits.
+- [referencias.md](referencias.md) — Reúne referencias utilizadas en la documentación.
+- [glosario.md](glosario.md) — Define términos generales usados en el proyecto.
+- [glosario-ingles-espanol.md](glosario-ingles-espanol.md) — Presenta un glosario bilingüe inglés-español de términos utilizados en el proyecto.
+- [migracion-mayor-version.md](migracion-mayor-version.md) — Documenta consideraciones para migraciones de versión mayor.
+
+---
+
+# 6. CI/CD y implementación
+
+- [integracion-ci.md](integracion-ci.md) — Explica la integración continua del proyecto.
+- [despliegue.md](despliegue.md) — Documenta el proceso de despliegue.
+- [benchmarks.md](benchmarks.md) — Presenta pruebas de rendimiento y mediciones comparativas.
+- [cobertura-tests.md](cobertura-tests.md) — Resume la cobertura de pruebas del proyecto.
+- [changelog-sprint-2.md](changelog-sprint-2.md) — Registra los cambios correspondientes al sprint 2.
+- [changelog-sprint-3.md](changelog-sprint-3.md) — Registra los cambios correspondientes al sprint 3.
+
+---
+
+## Organización del índice
+
+La documentación se organiza por categorías para facilitar la búsqueda de información según el tipo de usuario o tarea:
+
+- **Usuarios de la librería:** instalación, guías de uso, ejemplos, casos de uso y preguntas frecuentes.
+- **Contribuidores:** flujo Git, guía de contribución, estilo de commits y guía para agregar métodos.
+- **Mantenedores:** arquitectura, estándares, dependencias, CI/CD, despliegue, seguridad y roadmap.
+- **Referencia técnica:** métodos numéricos, API, validaciones, tipos de retorno, precisión y errores.
+
+


### PR DESCRIPTION
## ¿Qué hace este PR?
Este PR agrega un índice navegable maestro de la documentación del proyecto en `docs/indice-general.md`, organizando los documentos existentes dentro de `docs/` en las categorías solicitadas: arquitectura y estándares, guías de uso y ejemplos, métodos numéricos por categoría, contribución, CI/CD e implementación, y referencia de API. Cada documento cuenta con un enlace relativo y una breve descripción de una línea para facilitar la navegación de nuevos usuarios, colaboradores y mantenedores. Además, se agrega un enlace al índice general desde el `README.md`.

## Issue relacionado
Closes #687 

## Tipo de cambio
- [ ] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [x] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [x] Agregué tests si corresponde

## Evidencia / capturas

No aplica. Los cambios corresponden únicamente a documentación.