### PR TITLE
feat: agregar playground HTML standalone

### DIFF
--- a/playground/index.html
+++ b/playground/index.html
@@ -1,0 +1,57 @@
+ <!doctype html>
+<html lang="es">
+<head>
+  <meta charset="utf-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1" />
+  <title>Playground Trazo</title>
+  <link rel="stylesheet" href="./playground.css" />
+</head>
+<body>
+  <main class="app">
+    <section class="hero">
+      <p class="eyebrow">Trazo Playground</p>
+      <h1>Prueba métodos numéricos en el navegador</h1>
+      <p>
+        Ejecuta métodos representativos de Trazo directamente desde el navegador,
+        sin instalar dependencias ni levantar un servidor.
+      </p>
+      <p>
+        Este playground carga el bundle local <code>../dist/trazo.umd.js</code>.
+      </p>
+      <p id="bundle-status" class="status">Verificando bundle UMD...</p>
+    </section>
+
+    <section class="panel">
+      <div class="field">
+        <label for="method-select">Método</label>
+        <select id="method-select"></select>
+      </div>
+
+      <p id="method-description" class="description"></p>
+
+      <form id="param-form" class="form"></form>
+
+      <div class="actions">
+        <button id="run-button" type="button">Ejecutar</button>
+        <button id="example-button" type="button" class="secondary">Cargar ejemplo</button>
+      </div>
+    </section>
+
+    <section class="panel">
+      <h2>Resultado</h2>
+      <pre id="raw-output" class="output">Ejecuta un método para ver el resultado.</pre>
+
+      <h2>Tabla de iteraciones</h2>
+      <div class="table-wrapper">
+        <table id="result-table">
+          <thead></thead>
+          <tbody></tbody>
+        </table>
+      </div>
+    </section>
+  </main>
+
+  <script src="../dist/trazo.umd.js"></script>
+  <script src="./playground.js"></script>
+</body>
+</html>

--- a/playground/playground.css
+++ b/playground/playground.css
@@ -1,0 +1,181 @@
+:root {
+  --bg: #f4f6fb;
+  --card: #ffffff;
+  --text: #182033;
+  --muted: #657089;
+  --border: #d9deea;
+  --primary: #2563eb;
+  --primary-dark: #1d4ed8;
+  --danger: #b91c1c;
+  --success: #166534;
+  --code: #eef2ff;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  font-family: Arial, Helvetica, sans-serif;
+  color: var(--text);
+  background: var(--bg);
+}
+
+.app {
+  width: min(1100px, calc(100% - 32px));
+  margin: 32px auto;
+}
+
+.hero,
+.panel {
+  background: var(--card);
+  border: 1px solid var(--border);
+  border-radius: 16px;
+  padding: 24px;
+  margin-bottom: 20px;
+  box-shadow: 0 10px 24px rgba(20, 30, 55, 0.08);
+}
+
+.eyebrow {
+  margin: 0 0 8px;
+  color: var(--primary);
+  font-weight: 700;
+  text-transform: uppercase;
+  letter-spacing: 0.08em;
+  font-size: 0.8rem;
+}
+
+h1,
+h2 {
+  margin-top: 0;
+}
+
+code {
+  background: var(--code);
+  padding: 2px 6px;
+  border-radius: 6px;
+}
+
+.status {
+  margin-top: 16px;
+  padding: 12px;
+  border-radius: 10px;
+  background: #eef2ff;
+  color: var(--primary-dark);
+  font-weight: 700;
+}
+
+.status.error {
+  background: #fee2e2;
+  color: var(--danger);
+}
+
+.status.ok {
+  background: #dcfce7;
+  color: var(--success);
+}
+
+.field {
+  margin-bottom: 16px;
+}
+
+label {
+  display: block;
+  font-weight: 700;
+  margin-bottom: 6px;
+}
+
+input,
+select,
+textarea {
+  width: 100%;
+  border: 1px solid var(--border);
+  border-radius: 10px;
+  padding: 10px 12px;
+  font-size: 1rem;
+  font-family: inherit;
+}
+
+textarea {
+  min-height: 90px;
+  resize: vertical;
+  font-family: Consolas, Monaco, monospace;
+}
+
+.description {
+  color: var(--muted);
+  margin-bottom: 18px;
+}
+
+.form {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 16px;
+}
+
+.form .field.wide {
+  grid-column: 1 / -1;
+}
+
+.actions {
+  display: flex;
+  gap: 12px;
+  margin-top: 20px;
+  flex-wrap: wrap;
+}
+
+button {
+  border: none;
+  border-radius: 10px;
+  padding: 11px 18px;
+  background: var(--primary);
+  color: white;
+  cursor: pointer;
+  font-weight: 700;
+}
+
+button:hover {
+  background: var(--primary-dark);
+}
+
+button.secondary {
+  background: #475569;
+}
+
+.output {
+  background: #101827;
+  color: #e5edff;
+  padding: 16px;
+  border-radius: 12px;
+  overflow: auto;
+  min-height: 90px;
+}
+
+.table-wrapper {
+  overflow: auto;
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  background: white;
+}
+
+th,
+td {
+  border: 1px solid var(--border);
+  padding: 10px;
+  text-align: left;
+  vertical-align: top;
+}
+
+th {
+  background: #eef2ff;
+}
+
+@media (max-width: 720px) {
+  .form {
+    grid-template-columns: 1fr;
+  }
+}

--- a/playground/playground.js
+++ b/playground/playground.js
@@ -1,0 +1,428 @@
+(function () {
+  "use strict";
+
+  const methods = [
+    {
+      id: "biseccion",
+      label: "Bisección",
+      category: "Ecuaciones no lineales",
+      exports: ["biseccion", "bisection", "metodoBiseccion", "resolverBiseccion"],
+      description: "Método de intervalo para encontrar una raíz de f(x).",
+      fields: [
+        { name: "f", label: "f(x)", type: "expression", value: "x^3 - x - 2" },
+        { name: "a", label: "a", type: "number", value: "1" },
+        { name: "b", label: "b", type: "number", value: "2" },
+        { name: "tolerancia", label: "Tolerancia", type: "number", value: "0.0001" },
+        { name: "maxIteraciones", label: "Máx. iteraciones", type: "number", value: "50" }
+      ]
+    },
+    {
+      id: "newton",
+      label: "Newton-Raphson",
+      category: "Ecuaciones no lineales",
+      exports: ["newtonRaphson", "newton", "metodoNewton", "metodoNewtonRaphson"],
+      description: "Método abierto que usa f(x), su derivada y un valor inicial.",
+      fields: [
+        { name: "f", label: "f(x)", type: "expression", value: "x^2 - 2" },
+        { name: "df", label: "f'(x)", type: "expression", value: "2*x" },
+        { name: "x0", label: "x0", type: "number", value: "1" },
+        { name: "tolerancia", label: "Tolerancia", type: "number", value: "0.0001" },
+        { name: "maxIteraciones", label: "Máx. iteraciones", type: "number", value: "50" }
+      ]
+    },
+    {
+      id: "secante",
+      label: "Secante",
+      category: "Ecuaciones no lineales",
+      exports: ["secante", "secant", "metodoSecante"],
+      description: "Método abierto que aproxima la raíz usando dos valores iniciales.",
+      fields: [
+        { name: "f", label: "f(x)", type: "expression", value: "x^3 - x - 2" },
+        { name: "x0", label: "x0", type: "number", value: "1" },
+        { name: "x1", label: "x1", type: "number", value: "2" },
+        { name: "tolerancia", label: "Tolerancia", type: "number", value: "0.0001" },
+        { name: "maxIteraciones", label: "Máx. iteraciones", type: "number", value: "50" }
+      ]
+    },
+    {
+      id: "gauss",
+      label: "Eliminación Gaussiana",
+      category: "Sistemas lineales",
+      exports: ["gauss", "eliminacionGauss", "gaussiana", "resolverGauss", "metodoGauss"],
+      description: "Resuelve un sistema lineal Ax = b.",
+      fields: [
+        { name: "matriz", label: "Matriz A", type: "json", wide: true, value: "[[2,1,-1],[-3,-1,2],[-2,1,2]]" },
+        { name: "vector", label: "Vector b", type: "json", wide: true, value: "[8,-11,-3]" }
+      ]
+    },
+    {
+      id: "horner",
+      label: "Horner",
+      category: "Polinomios",
+      exports: ["horner", "metodoHorner", "evaluarHorner", "evaluarPolinomioHorner"],
+      description: "Evalúa un polinomio en un punto usando el esquema de Horner.",
+      fields: [
+        { name: "coeficientes", label: "Coeficientes", type: "json", wide: true, value: "[2,-6,2,-1]" },
+        { name: "x", label: "x", type: "number", value: "3" }
+      ]
+    },
+    {
+      id: "trapecio",
+      label: "Regla del Trapecio",
+      category: "Integración numérica",
+      exports: ["trapecio", "reglaTrapecio", "integracionTrapecio", "metodoTrapecio"],
+      description: "Aproxima una integral definida con la regla del trapecio.",
+      fields: [
+        { name: "f", label: "f(x)", type: "expression", value: "x^2" },
+        { name: "a", label: "a", type: "number", value: "0" },
+        { name: "b", label: "b", type: "number", value: "2" },
+        { name: "n", label: "Subintervalos", type: "number", value: "10" }
+      ]
+    },
+    {
+      id: "eulerMejorado",
+      label: "Euler mejorado",
+      category: "Ecuaciones diferenciales",
+      exports: ["eulerMejorado", "heun", "metodoEulerMejorado", "eulerModificado"],
+      description: "Aproxima la solución de una EDO de primer orden y' = f(x, y).",
+      fields: [
+        { name: "f", label: "f(x, y)", type: "expression", value: "x + y" },
+        { name: "x0", label: "x0", type: "number", value: "0" },
+        { name: "y0", label: "y0", type: "number", value: "1" },
+        { name: "h", label: "Paso h", type: "number", value: "0.1" },
+        { name: "n", label: "Pasos", type: "number", value: "10" }
+      ]
+    }
+  ];
+
+  const methodSelect = document.getElementById("method-select");
+  const methodDescription = document.getElementById("method-description");
+  const paramForm = document.getElementById("param-form");
+  const runButton = document.getElementById("run-button");
+  const exampleButton = document.getElementById("example-button");
+  const rawOutput = document.getElementById("raw-output");
+  const table = document.getElementById("result-table");
+  const bundleStatus = document.getElementById("bundle-status");
+
+  function getLibraryRoots() {
+    return [
+      window.Trazo,
+      window.trazo,
+      window.TrazoMath,
+      window.trazoMath,
+      window.TrazoJS,
+      window.trazojs
+    ].filter(Boolean);
+  }
+
+  function updateBundleStatus() {
+    const roots = getLibraryRoots();
+
+    if (roots.length > 0) {
+      bundleStatus.textContent = "Bundle UMD cargado correctamente desde ../dist/trazo.umd.js.";
+      bundleStatus.className = "status ok";
+    } else {
+      bundleStatus.textContent = "No se detectó el bundle UMD. Verifica que exista dist/trazo.umd.js.";
+      bundleStatus.className = "status error";
+    }
+  }
+
+  function normalizeExpression(expression) {
+    return String(expression).replace(/\^/g, "**");
+  }
+
+  function compileExpression(expression) {
+    const normalized = normalizeExpression(expression);
+
+    return new Function(
+      "x",
+      "y",
+      `
+      "use strict";
+      const sin = Math.sin;
+      const cos = Math.cos;
+      const tan = Math.tan;
+      const exp = Math.exp;
+      const log = Math.log;
+      const sqrt = Math.sqrt;
+      const abs = Math.abs;
+      const pow = Math.pow;
+      const pi = Math.PI;
+      const e = Math.E;
+      return (${normalized});
+      `
+    );
+  }
+
+  function findExport(names) {
+    const roots = getLibraryRoots();
+    const lowerNames = names.map((name) => name.toLowerCase());
+
+    for (const root of roots) {
+      const found = findInObject(root, lowerNames, new Set(), 0);
+      if (found) return found;
+    }
+
+    return null;
+  }
+
+  function findInObject(obj, lowerNames, visited, depth) {
+    if (!obj || visited.has(obj) || depth > 4) return null;
+    visited.add(obj);
+
+    for (const key of Object.keys(obj)) {
+      if (lowerNames.includes(key.toLowerCase()) && typeof obj[key] === "function") {
+        return obj[key];
+      }
+    }
+
+    for (const key of Object.keys(obj)) {
+      const value = obj[key];
+
+      if (value && typeof value === "object") {
+        const found = findInObject(value, lowerNames, visited, depth + 1);
+        if (found) return found;
+      }
+    }
+
+    return null;
+  }
+
+  function populateMethods() {
+    methods.forEach((method) => {
+      const option = document.createElement("option");
+      option.value = method.id;
+      option.textContent = `${method.label} — ${method.category}`;
+      methodSelect.appendChild(option);
+    });
+  }
+
+  function currentMethod() {
+    return methods.find((method) => method.id === methodSelect.value);
+  }
+
+  function renderFields() {
+    const method = currentMethod();
+    methodDescription.textContent = method.description;
+    paramForm.innerHTML = "";
+
+    method.fields.forEach((field) => {
+      const wrapper = document.createElement("div");
+      wrapper.className = field.wide ? "field wide" : "field";
+
+      const label = document.createElement("label");
+      label.setAttribute("for", field.name);
+      label.textContent = field.label;
+
+      const input = field.type === "json"
+        ? document.createElement("textarea")
+        : document.createElement("input");
+
+      input.id = field.name;
+      input.name = field.name;
+      input.value = field.value;
+
+      if (field.type === "number") {
+        input.type = "number";
+        input.step = "any";
+      } else if (field.type === "expression") {
+        input.type = "text";
+      }
+
+      wrapper.appendChild(label);
+      wrapper.appendChild(input);
+      paramForm.appendChild(wrapper);
+    });
+  }
+
+  function readValues(method) {
+    const values = {};
+
+    method.fields.forEach((field) => {
+      const element = document.getElementById(field.name);
+      const value = element.value.trim();
+
+      if (field.type === "number") {
+        values[field.name] = Number(value);
+      } else if (field.type === "json") {
+        values[field.name] = JSON.parse(value);
+      } else if (field.type === "expression") {
+        values[field.name] = compileExpression(value);
+        values[`${field.name}Texto`] = value;
+      } else {
+        values[field.name] = value;
+      }
+    });
+
+    return values;
+  }
+
+  function callWithFallbacks(method, fn, p) {
+    const max = p.maxIteraciones;
+    const tol = p.tolerancia;
+
+    const attempts = {
+      biseccion: [
+        () => fn({ f: p.f, funcion: p.f, a: p.a, b: p.b, tolerancia: tol, maxIteraciones: max }),
+        () => fn(p.f, p.a, p.b, tol, max)
+      ],
+      newton: [
+        () => fn({ f: p.f, funcion: p.f, df: p.df, derivada: p.df, x0: p.x0, tolerancia: tol, maxIteraciones: max }),
+        () => fn(p.f, p.df, p.x0, tol, max)
+      ],
+      secante: [
+        () => fn({ f: p.f, funcion: p.f, x0: p.x0, x1: p.x1, tolerancia: tol, maxIteraciones: max }),
+        () => fn(p.f, p.x0, p.x1, tol, max)
+      ],
+      gauss: [
+        () => fn({ matriz: p.matriz, vector: p.vector, A: p.matriz, b: p.vector }),
+        () => fn(p.matriz, p.vector)
+      ],
+      horner: [
+        () => fn({ coeficientes: p.coeficientes, coefficients: p.coeficientes, x: p.x }),
+        () => fn(p.coeficientes, p.x)
+      ],
+      trapecio: [
+        () => fn({ f: p.f, funcion: p.f, a: p.a, b: p.b, n: p.n, subintervalos: p.n }),
+        () => fn(p.f, p.a, p.b, p.n)
+      ],
+      eulerMejorado: [
+        () => fn({ f: p.f, funcion: p.f, x0: p.x0, y0: p.y0, h: p.h, n: p.n, pasos: p.n }),
+        () => fn(p.f, p.x0, p.y0, p.h, p.n)
+      ]
+    };
+
+    let lastError = null;
+
+    for (const attempt of attempts[method.id] || []) {
+      try {
+        return attempt();
+      } catch (error) {
+        lastError = error;
+      }
+    }
+
+    throw lastError || new Error("No se pudo ejecutar el método seleccionado.");
+  }
+
+  function extractIterations(result) {
+    if (Array.isArray(result)) return result;
+
+    const keys = [
+      "iteraciones",
+      "iterations",
+      "tabla",
+      "table",
+      "historial",
+      "pasos",
+      "steps"
+    ];
+
+    for (const key of keys) {
+      if (result && Array.isArray(result[key])) return result[key];
+    }
+
+    if (result && result.resultado) {
+      for (const key of keys) {
+        if (Array.isArray(result.resultado[key])) return result.resultado[key];
+      }
+    }
+
+    return [];
+  }
+
+  function renderRaw(result) {
+    rawOutput.textContent = JSON.stringify(
+      result,
+      function (_key, value) {
+        if (typeof value === "function") return "[Function]";
+        return value;
+      },
+      2
+    );
+  }
+
+  function renderTable(iterations) {
+    const thead = table.querySelector("thead");
+    const tbody = table.querySelector("tbody");
+
+    thead.innerHTML = "";
+    tbody.innerHTML = "";
+
+    if (!iterations.length) {
+      const row = document.createElement("tr");
+      const cell = document.createElement("td");
+
+      cell.textContent = "El resultado no incluye una tabla de iteraciones.";
+      row.appendChild(cell);
+      tbody.appendChild(row);
+
+      return;
+    }
+
+    const columns = Object.keys(iterations[0]);
+    const headerRow = document.createElement("tr");
+
+    columns.forEach((column) => {
+      const th = document.createElement("th");
+      th.textContent = column;
+      headerRow.appendChild(th);
+    });
+
+    thead.appendChild(headerRow);
+
+    iterations.forEach((item) => {
+      const row = document.createElement("tr");
+
+      columns.forEach((column) => {
+        const cell = document.createElement("td");
+        const value = item[column];
+
+        cell.textContent = typeof value === "object"
+          ? JSON.stringify(value)
+          : String(value);
+
+        row.appendChild(cell);
+      });
+
+      tbody.appendChild(row);
+    });
+  }
+
+  function runSelectedMethod() {
+    const method = currentMethod();
+    const fn = findExport(method.exports);
+
+    if (!fn) {
+      const names = method.exports.join(", ");
+      rawOutput.textContent = `No se encontró el método exportado para "${method.label}". Nombres buscados: ${names}.`;
+      renderTable([]);
+      return;
+    }
+
+    try {
+      const values = readValues(method);
+      const result = callWithFallbacks(method, fn, values);
+
+      renderRaw(result);
+      renderTable(extractIterations(result));
+    } catch (error) {
+      rawOutput.textContent = error && error.stack ? error.stack : String(error);
+      renderTable([]);
+    }
+  }
+
+  function loadExample() {
+    renderFields();
+    rawOutput.textContent = "Ejemplo cargado. Presiona Ejecutar.";
+    renderTable([]);
+  }
+
+  methodSelect.addEventListener("change", loadExample);
+  runButton.addEventListener("click", runSelectedMethod);
+  exampleButton.addEventListener("click", loadExample);
+
+  populateMethods();
+  renderFields();
+  updateBundleStatus();
+})();


### PR DESCRIPTION
## ¿Qué hace este PR?
Este PR agrega un playground HTML standalone en la carpeta `playground/`, permitiendo probar métodos representativos de Trazo directamente desde el navegador sin instalar dependencias ni levantar un servidor. La interfaz incluye selector de método, campos de entrada dinámicos según el método elegido, botón de ejecución, área de resultado y tabla de iteraciones. El playground carga el bundle local `../dist/trazo.umd.js`, por lo que queda preparado para funcionar mediante `file://` cuando el bundle UMD esté disponible, sin depender de recursos externos ni servicios de red.

## Issue relacionado
Closes #633 

## Tipo de cambio
- [x] feat — nueva funcionalidad
- [ ] fix — corrección de error
- [ ] docs — documentación
- [ ] test — pruebas
- [ ] chore — configuración
- [ ] refactor — mejora sin cambio funcional
- [ ] security — seguridad
- [ ] data — análisis de datos

## Checklist
- [x] Mi código sigue los estándares del proyecto
- [x] Actualicé la documentación correspondiente
- [x] Mis cambios no rompen funcionalidad existente
- [x] Agregué tests si corresponde

## Evidencia / capturas
Se agregaron únicamente los archivos solicitados para el playground: `playground/index.html`, `playground/playground.css` y `playground/playground.js`. 
